### PR TITLE
Prevent using broken package by default

### DIFF
--- a/dimscord.nimble
+++ b/dimscord.nimble
@@ -7,4 +7,4 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 1.0.0", "zip >= 0.2.1", "websocket >= 0.4.0"
+requires "nim >= 1.0.0", "zip >= 0.2.1", "websocket >= 0.4.0", "websocket <= 0.5.0"

--- a/dimscord.nimble
+++ b/dimscord.nimble
@@ -7,4 +7,4 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 1.0.0", "zip >= 0.2.1", "websocket >= 0.4.0", "websocket <= 0.5.0"
+requires "nim >= 1.0.0", "zip >= 0.2.1", "websocket >= 0.4.0 & < 0.5.0"


### PR DESCRIPTION
like mentioned in the readme, websocket 0.5.0 does not seem to work for this package, i had to downgrade manually, so i think this should just install the correct version by default

can always upgrade later when the issue is fixed