### PR TITLE
generate an invite link

### DIFF
--- a/dimscord/misc.nim
+++ b/dimscord/misc.nim
@@ -185,8 +185,8 @@ proc genInviteLink*(client_id: string, permissions: set[PermEnum] = {};
     ## 
     ## See https://discord.com/developers/docs/topics/oauth2#bots for more information.
     result = restBase & "oauth2/authorize?client_id=" & client_id &
-        "&scope=bot&permissions=" & $cast[int](permissions) &
-            "&disable_guild_select=true" & $disable_guild_select
+        "&scope=bot&permissions=" & $cast[int](permissions)   
 
     if guild_id != "":
-        result &= "&guild_id=" & guild_id
+        result &= "&guild_id=" & guild_id &
+            "&disable_guild_select=" & $disable_guild_select

--- a/dimscord/misc.nim
+++ b/dimscord/misc.nim
@@ -175,3 +175,12 @@ proc readPerms*(guild: Guild, member: Member, channel: GuildChannel): PermObj =
 
     perms = (perms and deny - deny - deny - 1) or allow
     result = PermObj(allowed: cast[set[PermEnum]](perms))
+
+func inviteLink*(user: User, permissions: set[PermEnum] = {}, guild = none(Guild), disableGuildSelect = false): string =
+    ## Creates an invite link for the bot of the form https://discord.com/api/oauth2/authorize?client_id=157730590492196864&scope=bot&permissions=1
+    ## see https://discord.com/developers/docs/topics/oauth2#bots for more information
+    result = restBase & "oauth2/authorize?client_id=" & user.id & "&scope=bot&permissions=" & $cast[int](permissions)
+    if guild.isSome:
+        result &= "&guild_id=" & guild.get.id
+        if disableGuildSelect:
+            result &= "&disable_guild_select=true"

--- a/dimscord/misc.nim
+++ b/dimscord/misc.nim
@@ -176,11 +176,17 @@ proc readPerms*(guild: Guild, member: Member, channel: GuildChannel): PermObj =
     perms = (perms and deny - deny - deny - 1) or allow
     result = PermObj(allowed: cast[set[PermEnum]](perms))
 
-func inviteLink*(user: User, permissions: set[PermEnum] = {}, guild = none(Guild), disableGuildSelect = false): string =
-    ## Creates an invite link for the bot of the form https://discord.com/api/oauth2/authorize?client_id=157730590492196864&scope=bot&permissions=1
-    ## see https://discord.com/developers/docs/topics/oauth2#bots for more information
-    result = restBase & "oauth2/authorize?client_id=" & user.id & "&scope=bot&permissions=" & $cast[int](permissions)
-    if guild.isSome:
-        result &= "&guild_id=" & guild.get.id
-        if disableGuildSelect:
-            result &= "&disable_guild_select=true"
+proc genInviteLink*(client_id: string, permissions: set[PermEnum] = {};
+        guild_id = ""; disable_guild_select = false): string =
+    ## Creates an invite link for the bot of the form.
+    ## 
+    ## Example:
+    ## `https://discord.com/api/oauth2/authorize?client_id=666&scope=bot&permissions=1`
+    ## 
+    ## See https://discord.com/developers/docs/topics/oauth2#bots for more information.
+    result = restBase & "oauth2/authorize?client_id=" & client_id &
+        "&scope=bot&permissions=" & $cast[int](permissions) &
+            "&disable_guild_select=true" & $disable_guild_select
+
+    if guild_id != "":
+        result &= "&guild_id=" & guild_id


### PR DESCRIPTION
Hello,
we spoke on discord about this feature. An invite link as seen here https://discord.com/developers/docs/topics/oauth2#bots will be generated. I opened the PR to get started, please let me know what to change/improve since I'm new to nim, discord bots and your library. I hope it is not completely different than what you had in mind.

I wasn't sure about the permissions. Should I rather change that parameter to PermObj type?