### PR TITLE
Add string values to PermEnum

### DIFF
--- a/dimscord/constants.nim
+++ b/dimscord/constants.nim
@@ -13,7 +13,7 @@ type
         permAddReactions = "Add Reactions"
         permViewAuditLogs = "View Audit Log"
         permPrioritySpeaker = "Priority Speaker"
-        permVoiceStream = "VoiceStream"
+        permVoiceStream = "Voice Stream"
         permViewChannel = "View Channel"
         permSendMessages = "Send Messages"
         permSendTTSMessage = "Send TTS Messages"

--- a/dimscord/constants.nim
+++ b/dimscord/constants.nim
@@ -4,37 +4,37 @@ when defined(dimscordDebug):
 
 type
     PermEnum* = enum
-        permCreateInstantInvite
-        permKickMembers
-        permBanMembers
-        permAdministrator
-        permManageChannels
-        permManageGuild
-        permAddReactions
-        permViewAuditLogs
-        permPrioritySpeaker
-        permVoiceStream
-        permViewChannel
-        permSendMessages
-        permSendTTSMessage
-        permManageMessages
-        permEmbedLinks
-        permAttachFiles
-        permReadMessageHistory
-        permMentionEveryone
-        permUseExternalEmojis
-        permViewGuildInsights
-        permVoiceConnect
-        permVoiceSpeak
-        permVoiceMuteMembers
-        permVoiceDeafenMembers
-        permVoiceMoveMembers
-        permUseVAD
-        permChangeNickname
-        permManageNicknames
-        permManageRoles
-        permManageWebhooks
-        permManageEmojis
+        permCreateInstantInvite = "Create Instant Invite"
+        permKickMembers = "Kick Members"
+        permBanMembers = "Ban Members"
+        permAdministrator = "Administrator"
+        permManageChannels = "Manage Channels"
+        permManageGuild = "Manage Server"
+        permAddReactions = "Add Reactions"
+        permViewAuditLogs = "View Audit Log"
+        permPrioritySpeaker = "Priority Speaker"
+        permVoiceStream = "VoiceStream"
+        permViewChannel = "View Channel"
+        permSendMessages = "Send Messages"
+        permSendTTSMessage = "Send TTS Messages"
+        permManageMessages = "Manage Messages"
+        permEmbedLinks = "Embed Links"
+        permAttachFiles = "Attach Files"
+        permReadMessageHistory = "Read Message History"
+        permMentionEveryone = "Mention @everyone, @here and All Roles"
+        permUseExternalEmojis = "Use External Emojis"
+        permViewGuildInsights = "View Guild Insights"
+        permVoiceConnect = "Voice Connect"
+        permVoiceSpeak = "Voice Speak"
+        permVoiceMuteMembers = "Voice Mute Members"
+        permVoiceDeafenMembers = "Voice Deafen Members"
+        permVoiceMoveMembers = "Voice Move Members"
+        permUseVAD = "Use VAD"
+        permChangeNickname = "Change Nickname"
+        permManageNicknames = "Manage Nicknames"
+        permManageRoles = "Manage Roles"
+        permManageWebhooks = "Manage Webhooks"
+        permManageEmojis = "Manage Emojis"
     GatewayIntent* = enum
         giGuilds,
         giGuildMembers,


### PR DESCRIPTION
We spoke about this on discord and I thought I'd prepare a PR then you can see if you like it or not :)

The string values are only used for `$` proc, the int values are not affected.  
I got the info from here https://nim-lang.org/docs/manual.html#types-enumeration-types (a little bit further down).

Small example that int values don't change: https://play.nim-lang.org/#ix=2rDU

The names I used I got from here https://discordapi.com/permissions.html, if I could not find one I just put spaces in the name.

(I made the PR to master because of the recent update. Let me know if I should change that.)