### PR TITLE
(;﹏;) fix annoying roles bug

### DIFF
--- a/dimscord/dispatch.nim
+++ b/dimscord/dispatch.nim
@@ -480,8 +480,8 @@ proc guildMemberUpdate(s: Shard, data: JsonNode) {.async.} =
     if "premium_since" in data and data["premium_since"].kind != JNull:
         member.premium_since = some data["premium_since"].str
 
+    member.roles = @[]
     for role in data["roles"].elems:
-        member.roles = @[]
         member.roles.add(role.str)
 
     await s.client.events.guild_member_update(s, guild, member, oldMember)


### PR DESCRIPTION
after a member had a role removed or added to them in a server, their roles sequence would always have a length of one