### PR TITLE
Switch from zip to zippy

### DIFF
--- a/dimscord.nimble
+++ b/dimscord.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.0.7"
+version       = "1.2.0"
 author        = "KrispPurg"
 description   = "A Discord Bot & REST Library for Nim."
 license       = "MIT"

--- a/dimscord.nimble
+++ b/dimscord.nimble
@@ -7,7 +7,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 1.2.0", "zip >= 0.2.1", "ws <= 0.4.0", "regex >= 0.15.0"
+requires "nim >= 1.2.0", "zippy >= 0.2.1", "ws <= 0.4.0", "regex >= 0.15.0"
 
 task genDoc, "Generates the documentation for dimscord":
     rmDir("docs") # Clean old doc folder

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -7,7 +7,7 @@ import tables, random, times, constants, objects, json, math
 import nativesockets, helpers
 
 when defined(discordCompress):
-    import zip/zlib
+    import zippy
 
 randomize()
 
@@ -410,7 +410,7 @@ proc handleSocketMessage(s: Shard) {.async.} =
 
         when defined(discordCompress):
             if packet[0] == Binary:
-                packet[1] = zlib.uncompress(packet[1])
+                packet[1] = uncompress(packet[1])
 
         try:
             data = parseJson(packet[1])


### PR DESCRIPTION
By using [zippy](https://github.com/guzba/zippy/) instead of zip, the external zlib1 file dependency is no longer needed

I have tested that `uncompress` is called with the `advanced.nim` example and it seemed to work correctly