### PR TITLE
Removing trailing slash from global commands endpoint

### DIFF
--- a/dimscord/constants.nim
+++ b/dimscord/constants.nim
@@ -399,7 +399,7 @@ proc endpointOAuth2Application*(): string =
     result = "oauth2/applications/@me"
 
 proc endpointGlobalCommands*(aid: string; cid = ""): string =
-    result = "applications/" & aid & "/commands/" & (if cid != "": cid else: "")
+    result = "applications/" & aid & "/commands" & (if cid != "": "/" & cid else: "")
 
 proc endpointGuildCommands*(aid, gid: string; cid = ""): string =
     result = "applications/" & aid & "/guilds/" & gid & "/commands"


### PR DESCRIPTION
A 404 error happens when registering a global slash command.
This is because there is a trailing slash and so the url 
`"https://discord.com/api/v8/applications/<my_application_id>/commands/"`
is called instead of 
`"https://discord.com/api/v8/applications/<my_application_id>/commands"

I have tested this and it registers the command without 404 error