### PR TITLE
Add slash between commandID and rest of URL

### DIFF
--- a/dimscord/constants.nim
+++ b/dimscord/constants.nim
@@ -429,7 +429,7 @@ proc endpointGlobalCommands*(aid: string; cid = ""): string =
 proc endpointGuildCommands*(aid, gid: string; cid = ""): string =
     result = "applications/" & aid & "/guilds/" & gid & "/commands"
     if cid != "":
-        result &= cid
+        result &= "/" & cid
 
 proc endpointInteractionsCallback*(iid, it: string): string =
     result = "interactions/" & iid & "/" & it & "/callback"


### PR DESCRIPTION
There was no slash added between the commandID and the rest of the URL and so I was getting a 404

Tested this and it works