### PR TITLE
Fix nil access error in sendMessage

### DIFF
--- a/dimscord/restapi/message.nim
+++ b/dimscord/restapi/message.nim
@@ -7,7 +7,7 @@ proc sendMessage*(api: RestApi, channel_id: string;
         content = ""; tts = false; embed = none Embed;
         allowed_mentions = none AllowedMentions;
         nonce: Option[string] or Option[int] = none(int);
-        files = newSeq[DiscordFile](10);
+        files = newSeq[DiscordFile]();
         message_reference = none MessageReference
 ): Future[Message] {.async.} =
     ## Sends a discord message.


### PR DESCRIPTION
I was getting a nil access error since `files` was of default length 10 so it would try and access data from the files and cause a nil access error when sending messages

Tested the change and I now don't get `nil` access errors 