### PR TITLE
Fix getGuildChannel

### DIFF
--- a/dimscord/restapi/channel.nim
+++ b/dimscord/restapi/channel.nim
@@ -158,12 +158,12 @@ proc getChannelInvites*(api: RestApi,
         endpointChannelInvites(channel_id)
     )).elems.map(newInvite)
 
-proc getGuildChannel*(api: RestApi,
-        guild_id, channel_id: string): Future[GuildChannel] {.async.} =
+proc getChannel*(api: RestApi,
+        channel_id: string): Future[GuildChannel] {.async.} =
     ## Gets a guild channel.
     result = (await api.request(
         "GET",
-        endpointGuildChannels(guild_id, channel_id),
+        endpointChannels(channel_id),
     )).newGuildChannel
 
 proc getGuildChannels*(api: RestApi,


### PR DESCRIPTION
`getGuildChannel` was trying to request `/guilds/{guild.id}/channels/{channel.id}` but it returned a 404 error and I could not find it anywhere in the discord docs
but I did find [/channels/{channel.id}](https://discord.com/developers/docs/resources/channel#get-channel) which correctly returned the channel

I changed the name to `getChannel` so it fits with `deleteChannel` do you think it is a good name change or should I revert it back?