### PR TITLE
Fixed bulkOverwriteApplicationCommands

### DIFF
--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -846,6 +846,15 @@ proc `%%*`*(a: ApplicationCommandOption): JsonNode =
                 return %%*x # avoid conflicts with json
         )
 
+proc `%%*`*(a: ApplicationCommand): JsonNode =
+    assert a.name.len in 3..32
+    assert a.description.len in 1..100
+    result = %*{"name": a.name, "description": a.description}
+    if a.options.len > 0: result["options"] = %(a.options.map(
+        proc (x: ApplicationCommandOption): JsonNode =
+            %%*x
+    ))
+
 proc newApplicationCommand*(data: JsonNode): ApplicationCommand =
     result = ApplicationCommand(
         id: data["id"].str,

--- a/dimscord/restapi/user.nim
+++ b/dimscord/restapi/user.nim
@@ -118,6 +118,7 @@ proc getCurrentApplication*(api: RestApi): Future[OAuth2Application] {.async.} =
         endpointOAuth2Application()
     )).newOAuth2Application
 
+
 proc registerApplicationCommand*(api: RestApi; application_id: string;
         guild_id = ""; name, description: string;
         options: seq[ApplicationCommandOption] = @[]
@@ -175,16 +176,21 @@ proc getApplicationCommand*(
     )).newApplicationCommand
 
 proc bulkOverwriteApplicationCommands*(
-        api: RestApi, application_id: string; guild_id = ""
+        api: RestApi, application_id: string; commands: seq[ApplicationCommand], guild_id = ""
 ): Future[seq[ApplicationCommand]] {.async.} =
     ## Overwrites existing commands slash command that were registered in guild or application.
     ## - `guild_id` is optional.
+    let payload = %(commands.map(
+        proc (a: ApplicationCommand): JsonNode =
+            %%* a
+    ))
     result = (await api.request(
         "PUT",
         (if guild_id != "":
             endpointGuildCommands(application_id, guild_id)
         else:
             endpointGlobalCommands(application_id)),
+        $payload
     )).elems.map(newApplicationCommand)
 
 proc editApplicationCommand*(api: RestApi, application_id, command_id: string;

--- a/dimscord/restapi/user.nim
+++ b/dimscord/restapi/user.nim
@@ -179,6 +179,7 @@ proc bulkOverwriteApplicationCommands*(
         api: RestApi, application_id: string; commands: seq[ApplicationCommand], guild_id = ""
 ): Future[seq[ApplicationCommand]] {.async.} =
     ## Overwrites existing commands slash command that were registered in guild or application.
+    ## This means that only the commands you send in this request will be available globally or in a specific guild
     ## - `guild_id` is optional.
     let payload = %(commands.map(
         proc (a: ApplicationCommand): JsonNode =


### PR DESCRIPTION
`bulkOverwriteApplicationCommands` wasn't sending any commands in the payload

Will add a bit more documentation to make it clearer what the function does and also bit more testing (initial testing shows that it works so that's cool)