### PR TITLE
Typesafe command options

### DIFF
--- a/dimscord/constants.nim
+++ b/dimscord/constants.nim
@@ -229,6 +229,7 @@ type
         msfAPng = 2
         msfLottie = 3
     ApplicationCommandOptionType* = enum
+        acotNothing = 0 # Will never popup unless the user shoots themselves in the foot
         acotSubCommand = 1
         acotSubCommandGroup = 2
         acotStr = 3

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -760,21 +760,36 @@ proc newApplicationCommandInteractionDataOption(
     data: JsonNode
 ): ApplicationCommandInteractionDataOption =
     result = ApplicationCommandInteractionDataOption(
-        options: data{"options"}.getElems.map(
-            proc(x: JsonNode):(string,ApplicationCommandInteractionDataOption)=
-                (x["name"].str, newApplicationCommandInteractionDataOption(x))
-        ).toTable
+        kind: ApplicationCommandOptionType(data["type"].getInt())
     )
-    if "value" in data and data["value"].kind != JNull:
-        case data["value"].kind:
-        of JBool:
-            result.bval = some data["value"].bval
-        of JString:
-            result.str = some data["value"].str
-        of JInt:
-            result.ival = some data["value"].getInt
-        else:
-            discard
+    result.name = data["name"].getStr()
+    if result.kind notin {acotSubCommand, acotSubCommandGroup}:
+        # SubCommands/Groups don't have a value
+        let value = data["value"]
+        case result.kind
+            of acotBool:
+                result.bval = value.bval
+            of acotInt:
+                result.ival = value.getInt()
+            of acotStr:
+                result.str  = value.getStr()
+            of acotUser:
+                result.userID = value.getStr()
+            of acotChannel:
+                result.channelID = value.getStr()
+            of acotRole:
+                result.roleID = value.getStr()
+            else: discard
+    else:
+        # Convert the array of sub options into a key value table
+        result.options = toTable data{"options"}
+            .getElems
+            .map() do (x: JsonNode) -> (string, ApplicationCommandInteractionDataOption):
+                    (
+                        x["name"].str,
+                        newApplicationCommandInteractionDataOption(x)
+                    )
+
 
 proc newApplicationCommandInteractionData*(
     data: JsonNode

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -846,6 +846,15 @@ proc `%%*`*(a: ApplicationCommandOption): JsonNode =
                 return %%*x # avoid conflicts with json
         )
 
+proc `%%*`*(a: ApplicationCommand): JsonNode =
+    assert a.name.len in 3..32
+    assert a.description.len in 1..100
+    result = %*{"name": a.name, "description": a.description}
+    if a.options.len > 0: result["options"] = %(a.options.map(
+        proc (x: ApplicationCommandOption): JsonNode =
+            %%*x
+    ))
+
 proc newApplicationCommand*(data: JsonNode): ApplicationCommand =
     result = ApplicationCommand(
         id: data["id"].str,

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -345,11 +345,26 @@ type
         ## `options` Table[option_name, obj]
         id*, name*: string
         options*: Table[string, ApplicationCommandInteractionDataOption]
+
     ApplicationCommandInteractionDataOption* = object
-        bval*: Option[bool]
-        ival*: Option[int]
-        str*: Option[string]
-        options*: Table[string, ApplicationCommandInteractionDataOption]
+        name*: string
+        case kind*: ApplicationCommandOptionType
+            of acotNothing: discard
+            of acotBool:
+                bval*: bool
+            of acotInt:
+                ival*: int
+            of acotStr:
+                str*: string
+            of acotUser:
+                userID*: string
+            of acotChannel:
+                channelID*: string
+            of acotRole:
+                roleID*: string
+            of acotSubCommand, acotSubCommandGroup:
+                options*: Table[string, ApplicationCommandInteractionDataOption]
+
     InteractionResponse* = object
         kind*: InteractionResponseType
         data*: Option[InteractionApplicationCommandCallbackData]

--- a/dimscord/restapi/user.nim
+++ b/dimscord/restapi/user.nim
@@ -118,6 +118,7 @@ proc getCurrentApplication*(api: RestApi): Future[OAuth2Application] {.async.} =
         endpointOAuth2Application()
     )).newOAuth2Application
 
+
 proc registerApplicationCommand*(api: RestApi; application_id: string;
         guild_id = ""; name, description: string;
         options: seq[ApplicationCommandOption] = @[]
@@ -175,16 +176,21 @@ proc getApplicationCommand*(
     )).newApplicationCommand
 
 proc bulkOverwriteApplicationCommands*(
-        api: RestApi, application_id: string; guild_id = ""
+        api: RestApi, application_id: string; commands: seq[ApplicationCommand], guild_id = ""
 ): Future[seq[ApplicationCommand]] {.async.} =
     ## Overwrites existing commands slash command that were registered in guild or application.
     ## - `guild_id` is optional.
+    let payload = %(commands.map(
+        proc (a: ApplicationCommand): JsonNode =
+            %%* a
+    ))
     result = (await api.request(
         "PUT",
         (if guild_id != "":
             endpointGuildCommands(application_id, guild_id)
         else:
             endpointGlobalCommands(application_id)),
+        $payload
     )).elems.map(newApplicationCommand)
 
 proc editApplicationCommand*(api: RestApi, application_id, command_id: string;

--- a/dimscord/restapi/user.nim
+++ b/dimscord/restapi/user.nim
@@ -179,6 +179,7 @@ proc bulkOverwriteApplicationCommands*(
         api: RestApi, application_id: string; commands: seq[ApplicationCommand], guild_id = ""
 ): Future[seq[ApplicationCommand]] {.async.} =
     ## Overwrites existing commands slash command that were registered in guild or application.
+    ## This means that only the commands you send in this request will be available globally or in a specific guild
     ## - `guild_id` is optional.
     let payload = %(commands.map(
         proc (a: ApplicationCommand): JsonNode =

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,0 +1,1 @@
+switch("path", "$projectDir/../dimscord")

--- a/tests/testInteractions.nim
+++ b/tests/testInteractions.nim
@@ -1,0 +1,163 @@
+include objects
+import std/[
+    unittest,
+    json
+]
+
+template `%*%`(json: untyped): ApplicationCommandInteractionDataOption =
+    block:
+        let input = %* json
+        input.newApplicationCommandInteractionDataOption()
+
+suite "Interaction data types":
+    test "String":
+        let option = %*% {
+            "value": "foobar",
+            "type": 3,
+            "name": "word"
+        }
+        check:
+            option.kind == acotStr
+            option.str == "foobar"
+
+    test "Int":
+        let option = %*% {
+            "value": 42,
+            "type": 4,
+            "name": "answer"
+        }
+        check:
+            option.kind == acotInt
+            option.ival == 42
+
+    test "Bool":
+        let option = %*% {
+            "value": true,
+            "type": 5,
+            "name": "delete?"
+        }
+        check:
+            option.kind == acotBool
+            option.bval
+    test "User":
+        let option = %*% {
+            "value": "259999449995018240",
+            "type": 6,
+            "name": "person"
+        }
+        check:
+            option.kind == acotUser
+            option.userID == "259999449995018240"
+    test "Channel":
+        let option = %*% {
+            "value": "571779270498713603",
+            "type": 7,
+            "name": "thechannel"
+        }
+        check:
+            option.kind == acotChannel
+            option.channelID == "571779270498713603"
+
+    test "Role":
+        let option = %*% {
+            "value": "485396936384315402",
+            "type": 8,
+            "name": "newrole"
+        }
+        check:
+            option.kind == acotRole
+            option.roleID == "485396936384315402"
+
+
+suite "Interaction data":
+    test "Basic option":
+        ## Test that it can parse an interaction
+        ## data option
+        let option = %*% {
+                "value": "hello",
+                "type": 3,
+                "name": "name"
+              }
+        check:
+            option.kind == acotStr
+            option.str == "hello"
+            option.name == "name"
+
+    test "Basic command":
+        ## Test that it can parse a command
+        ## with no parameters
+        let input = %* {
+                   "name": "somecmd",
+                   "id": "852446885431738388"
+                 }
+        let data = input.newApplicationCommandInteractionData()
+        check:
+            data.name == "somecmd"
+            data.id == "852446885431738388"
+            data.options.len == 0
+
+    test "Command with parameter":
+        ## Test that it can parse a command
+        ## with a parameter
+        let input = %* {
+               "options": [
+                 {
+                   "value": "hello",
+                   "type": 3,
+                   "name": "name"
+                 }
+               ],
+               "name": "somecmd",
+               "id": "852446885431738388"
+             }
+        let data = input.newApplicationCommandInteractionData()
+        # Test the command is parsed right
+        check:
+            data.name == "somecmd"
+            data.id == "852446885431738388"
+            data.options.hasKey "name"
+
+        # Test the parameter is parsed right
+        let parameter = data.options["name"]
+        check:
+            parameter.name == "name"
+            parameter.kind == acotStr
+            parameter.str == "hello"
+
+    test "Sub Commands/Groups":
+        # Test that it can correctly parse sub commands
+        let input = %* {
+           "options": [
+             {
+               "type": 1,
+               "options": [
+                 {
+                   "value": 10,
+                   "type": 4,
+                   "name": "a"
+                 },
+                 {
+                   "value": 12,
+                   "type": 4,
+                   "name": "b"
+                 }
+               ],
+               "name": "add"
+             }
+           ],
+           "name": "calc",
+           "id": "861180910094254093"
+         }
+        let data = input.newApplicationCommandInteractionData()
+        check data.name == "calc"
+        # Check the sub command is parsed
+        check data.options.hasKey "add"
+        let subCmd = data.options["add"]
+        check:
+            subCmd.kind == acotSubCommand
+            subCmd.name == "add"
+            subCmd.options.len == 2
+        # Check the options are parsed correctly
+        check:
+            subCmd.options["a"].ival == 10
+            subCmd.options["b"].ival == 12


### PR DESCRIPTION
Interaction command options now have separate fields for the different possible values e.g.
```nim
# Simple example of behind the scenes
let input = %* {
            "value": "foobar",
            "type": 3,
            "name": "word"
}
let option = input.newApplicationCommandInteractionDataOption()
# Code that the developer would write
assert option.str == "word" # isn't an option anymore
assert option.ival == 9 # Throws an error since option.kind != acotInt
```

Also wrote some unit tests based on json responses from discord to test that this works in different scenarios 