### PR TITLE
W.I.P.: Add v9 support + threads

### DIFF
--- a/dimscord.nim
+++ b/dimscord.nim
@@ -63,7 +63,8 @@
 ## ==============
 ## - `-d:dimscordDebug` For debugging rest, gateway and voice.
 ## - `-d:discordCompress` Compress gateway payloads, by using zippy.
-## - `-d:discordv8` Discord API v8 if v6 or v7 is no longer function consider defining it.
+## - `-d:discordv8` Discord API v8 if v6 or v7 is no longer functioning consider defining it.
+## - `-d:discordv9` Discord API v9 if v6, v7 or v8 is no longer functioning consider defining it.
 ## - `-d:dimscordVoice` Enables the voice module. Requires libsodium
 
 import dimscord/[

--- a/dimscord/constants.nim
+++ b/dimscord/constants.nim
@@ -151,6 +151,9 @@ type
         ctGuildParent = 4
         ctGuildNews = 5
         ctGuildStore = 6
+        ctGuildNewsThread = 10
+        ctGuildPublicThread = 11
+        ctGuildPrivateThread = 12
         ctGuildStageVoice = 13
     MessageNotificationLevel* = enum
         mnlAllMessages = 0
@@ -317,6 +320,15 @@ proc endpointUserGuilds*(gid: string): string =
 proc endpointChannels*(cid = ""): string =
     result = "channels"
     if cid != "": result = result & "/" & cid
+
+proc endpointChannelThreads*(cid: string): string =
+    result = endpointChannels(cid) & "/threads"
+
+proc endpointMessageThreads*(cid: string, mid: string): string =
+    result = endpointChannels(cid) & "/messages/" & mid & "/threads"
+
+proc endpointChannelThreadMembers*(cid: string): string =
+    result = endpointChannels(cid) & "/thread-members"
 
 proc endpointGuilds*(gid = ""): string =
     result = "guilds" & (if gid != "": "/" & gid else: "")

--- a/dimscord/dispatch.nim
+++ b/dimscord/dispatch.nim
@@ -119,6 +119,8 @@ proc presenceUpdate(s: Shard, data: JsonNode) {.async.} =
         await s.client.events.presence_update(s, presence, oldPresence)
 
 proc messageCreate(s: Shard, data: JsonNode) {.async.} =
+    # TODO(dannyhpy): Messages from a thread aren't detected
+
     let msg = newMessage(data)
 
     if msg.channel_id in s.cache.guildChannels:
@@ -439,6 +441,22 @@ proc channelDelete(s: Shard, data: JsonNode) {.async.} =
 
     await s.client.events.channel_delete(s, guild, gc, dm)
 
+proc threadCreate(s: Shard, data: JsonNode) {.async.} =
+    # TODO(dannyhpy):
+    await s.client.events.thread_create(s)
+
+proc threadUpdate(s: Shard, data: JsonNode) {.async.} =
+    # TODO(dannyhpy):
+    await s.client.events.thread_update(s)
+
+proc threadDelete(s: Shard, data: JsonNode) {.async.} =
+    # TODO(dannyhpy):
+    await s.client.events.thread_delete(s)
+
+proc threadListSync(s: Shard, data: JsonNode) {.async.} =
+    # TODO(dannyhpy):
+    await s.client.events.thread_list_sync(s)
+
 proc guildMembersChunk(s: Shard, data: JsonNode) {.async.} =
     let guild = s.cache.guilds.getOrDefault(data["guild_id"].str,
         Guild(id: data["guild_id"].str)
@@ -702,6 +720,10 @@ proc handleEventDispatch*(s: Shard, event: string, data: JsonNode) {.async.} =
     of "CHANNEL_CREATE": await s.channelCreate(data)
     of "CHANNEL_UPDATE": await s.channelUpdate(data)
     of "CHANNEL_DELETE": await s.channelDelete(data)
+    of "THREAD_CREATE": await s.threadCreate(data)
+    of "THREAD_UPDATE": await s.threadUpdate(data)
+    of "THREAD_DELETE": await s.threadDelete(data)
+    of "THREAD_LIST_SYNC": await s.threadListSync(data)
     of "GUILD_MEMBERS_CHUNK": await s.guildMembersChunk(data)
     of "GUILD_MEMBER_ADD": await s.guildMemberAdd(data)
     of "GUILD_MEMBER_UPDATE": await s.guildMemberUpdate(data)

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -188,12 +188,20 @@ type
         id*, name*, guild_id*: string
         last_message_id*: string
         kind*: ChannelType
-        position*, rate_limit_per_user*: int
+        position*: Option[int]
+        rate_limit_per_user*: int
         bitrate*, user_limit*: int
-        parent_id*, topic*: Option[string]
+        parent_id*, owner_id*, topic*: Option[string]
         permission_overwrites*: Table[string, Overwrite]
+        message_count*, member_count*: Option[int]
+        thread_metadata*: Option[ThreadMetadata]
         messages*: Table[string, Message]
-        nsfw*: bool
+        nsfw*: Option[bool]
+    ThreadMetadata* = ref object
+        archived*: bool
+        # TODO(dannyhpy): archive_timestamp | ISO8601 timestamp
+        auto_archive_duration*: int
+        locked*: Option[bool]
     GameAssets* = object
         small_text*, small_image*: string
         large_text*, large_image*: string
@@ -523,6 +531,10 @@ type
                 c: Option[GuildChannel], d: Option[DMChannel]) {.async.}
         channel_pins_update*: proc (s: Shard, cid: string,
                 g: Option[Guild], last_pin: Option[string]) {.async.}
+        thread_create*: proc (s: Shard) {.async.} # TODO(dannyhpy):
+        thread_update*: proc (s: Shard) {.async.} # TODO(dannyhpy):
+        thread_delete*: proc (s: Shard) {.async.} # TODO(dannyhpy):
+        thread_list_sync*: proc (s: Shard) {.async.} # TODO(dannyhpy):
         presence_update*: proc (s: Shard, p: Presence,
                 o: Option[Presence]) {.async.}
         typing_start*: proc (s: Shard, t: TypingStart) {.async.}

--- a/dimscord/restapi.nim
+++ b/dimscord/restapi.nim
@@ -5,4 +5,4 @@
 ## 
 ## Endpoint aliases start here:
 ## https://discord.com/developers/docs/interactions/slash-commands#edit-original-interaction-response
-include restapi/[message, channel, guild, user]
+include restapi/[message, channel, thread, guild, user]

--- a/dimscord/restapi/thread.nim
+++ b/dimscord/restapi/thread.nim
@@ -1,0 +1,66 @@
+import asyncdispatch, json, options
+import ../objects, ../constants, ../helpers
+
+proc startThread*(api: RestApi,
+        channel_id: string, name: string,
+        channel_type = none int, reason = ""): Future[GuildChannel] {.async.} =
+    ## Starts a thread without a message.
+    let payload = %*{
+        "name": name,
+        "auto_archive_duration": 1440, # TODO(dannyhpy):
+        "type": channel_type,
+    }
+
+    result = (await api.request(
+        "POST",
+        endpointChannelThreads(channel_id),
+        $payload,
+        audit_reason = reason
+    )).newGuildChannel
+
+proc startThread*(api: RestApi, channel_id: string,
+        message_id: string, name: string,
+        reason = ""): Future[GuildChannel] {.async.} =
+    ## Starts a thread with a message.
+    let payload = %*{
+        "name": name,
+        "auto_archive_duration": 1440, # TODO(dannyhpy):
+    }
+
+    result = (await api.request(
+        "POST",
+        endpointMessageThreads(channel_id, message_id),
+        $payload,
+        audit_reason = reason
+    )).newGuildChannel
+
+proc addThreadMember*(api: RestApi, thread_id: string,
+        member_id: string) {.async.} =
+    ## Adds a thread member.
+    discard await api.request(
+        "PUT",
+        endpointChannelThreadMembers(thread_id) & "/" & member_id,
+    )
+
+proc removeThreadMember*(api: RestApi, thread_id: string,
+        member_id: string) {.async.} =
+    ## Removes a thread member.
+    discard await api.request(
+        "DELETE",
+        endpointChannelThreadMembers(thread_id) & "/" & member_id,
+    )
+
+proc joinThread*(api: RestApi, thread_id: string) {.async.} =
+    ## Join a thread.
+    await api.addThreadMember(thread_id, "@me")
+
+proc leaveThread*(api: RestApi, thread_id: string) {.async.} =
+    ## Leave a thread.
+    await api.removeThreadMember(thread_id, "@me")
+
+# TODO(dannyhpy): Missing endpoints
+#   - List thread members
+#   - List active threads
+#   - List public archived threads
+#   - List private archived threads
+#   - List joined private archived threads


### PR DESCRIPTION
This is a draft. There is a lot of things I'm unsure about at the moment.

Threads are only available in **v9** ; using `-d:dimscordv9` is necessary in order to use them.
```nim
var discord: DiscordClient
var channel: GuildChannel

# ...

## Creates a thread
var threadChannel = await discord.api.startThread(channel.id, "test")
## Deletes it
await discord.api.deleteChannel(threadChannel.id)
```

There are a lot of properties in **GuildChannel** that are marked as _optionnal_ in the Discord docs even though they're mandatory in the library (for instance, `rate_limit_per_user`). What about making them optional? 