### PR TITLE
Add autocomplete

### DIFF
--- a/dimscord/constants.nim
+++ b/dimscord/constants.nim
@@ -296,6 +296,7 @@ type
         itPing =               1
         itApplicationCommand = 2
         itMessageComponent =   3
+        itAutoComplete =       4
     InteractionDataType* = enum
         idtApplicationCommand
         idtComponent
@@ -305,6 +306,7 @@ type
         irtDeferredChannelMessageWithSource = 5
         irtDeferredUpdateMessage =            6
         irtUpdateMessage =                    7
+        irtAutoCompleteResult =               8
     InviteTargetType* = enum
         ittStream =              1
         ittEmbeddedApplication = 2

--- a/dimscord/constants.nim
+++ b/dimscord/constants.nim
@@ -301,6 +301,7 @@ type
         idtApplicationCommand
         idtComponent
     InteractionResponseType* = enum
+        irtInvalid =                          0
         irtPong =                             1
         irtChannelMessageWithSource =         4
         irtDeferredChannelMessageWithSource = 5

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -910,6 +910,8 @@ proc newApplicationCommandInteractionDataOption(
         of acotRole:
             result.role_id    = value.getStr
         else: discard
+        if "focused" in data:
+          result.focused = some data["focused"].getBool()
     else:
         # Convert the array of sub options into a key value table
         result.options = toTable data{"options"}
@@ -1006,7 +1008,8 @@ proc newApplicationCommandOption*(data: JsonNode): ApplicationCommandOption =
 proc `%%*`*(a: ApplicationCommandOption): JsonNode =
     result = %*{"type": int a.kind, "name": a.name,
                 "description": a.description,
-                "required": %(a.required.get false)
+                "required": %(a.required.get false),
+                "autocomplete": %a.autocomplete
     }
 
     if a.choices.len > 0:

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -473,8 +473,11 @@ type
         focused*: Option[bool] ## Will be true if this is the value the user is typing during auto complete
     InteractionResponse* = object
         case kind*: InteractionResponseType
-        of irtPong, irtChannelMessageWithSource, irtDeferredChannelMessageWithSource,
-                irtDeferredUpdateMessage, irtUpdateMessage:
+        of irtPong,
+           irtChannelMessageWithSource,
+           irtDeferredChannelMessageWithSource,
+           irtDeferredUpdateMessage,
+           irtUpdateMessage:
             data*: Option[InteractionApplicationCommandCallbackData]
         of irtAutoCompleteResult:
             choices*: seq[ApplicationCommandOptionChoice]

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -408,7 +408,7 @@ type
     ApplicationCommandOption* = object
         kind*: ApplicationCommandOptionType
         name*, description*: string
-        required*: Option[bool]
+        required*, autocomplete*: Option[bool]
         choices*: seq[ApplicationCommandOptionChoice]
         options*: seq[ApplicationCommandOption]
     ApplicationCommandOptionChoice* = object
@@ -470,6 +470,7 @@ type
             options*: Table[string, ApplicationCommandInteractionDataOption]
         of acotNumber: fval*: float
         of acotMentionable: mention_id*: string
+        focused: Option[bool] ## Will be true if this is the value the user is typing during auto complete
     InteractionResponse* = object
         kind*: InteractionResponseType
         data*: Option[InteractionApplicationCommandCallbackData]

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -470,10 +470,15 @@ type
             options*: Table[string, ApplicationCommandInteractionDataOption]
         of acotNumber: fval*: float
         of acotMentionable: mention_id*: string
-        focused: Option[bool] ## Will be true if this is the value the user is typing during auto complete
+        focused*: Option[bool] ## Will be true if this is the value the user is typing during auto complete
     InteractionResponse* = object
-        kind*: InteractionResponseType
-        data*: Option[InteractionApplicationCommandCallbackData]
+        case kind*: InteractionResponseType
+        of irtPong, irtChannelMessageWithSource, irtDeferredChannelMessageWithSource,
+                irtDeferredUpdateMessage, irtUpdateMessage:
+            data*: Option[InteractionApplicationCommandCallbackData]
+        of irtAutoCompleteResult:
+            choices*: seq[ApplicationCommandOptionChoice]
+        of irtInvalid: discard
     InteractionApplicationCommandCallbackData* = object
         tts*: Option[bool]
         content*: string

--- a/dimscord/restapi/user.nim
+++ b/dimscord/restapi/user.nim
@@ -257,8 +257,11 @@ proc createInteractionResponse*(api: RestApi,
     ## `response.kind` is required.
     var data = newJObject()
     case response.kind:
-    of irtPong, irtChannelMessageWithSource, irtDeferredChannelMessageWithSource,
-        irtDeferredUpdateMessage, irtUpdateMessage:
+    of irtPong,
+       irtChannelMessageWithSource,
+       irtDeferredChannelMessageWithSource,
+       irtDeferredUpdateMessage,
+       irtUpdateMessage:
         data = %response.data
         if response.data.isSome:
             data["flags"] = %int response.data.get.flags


### PR DESCRIPTION
Implements [autocomplete](https://discord.com/developers/docs/interactions/application-commands#autocomplete) for interactions

basic example
```nim
proc interactionCreate(s: Shard, i: Interaction) {.event(discord).} =
    if i.kind == itAutoComplete:
        let things = [
            " and self",
            " and friends",
            " and co"
        ]
        if i.data.isSome:
            for key, option in i.data.get().options:
                if option.focused.get(false):
                    var choices: seq[ApplicationCommandOptionChoice] = @[]
                    for thing in things:
                        choices &= ApplicationCommandOptionChoice(
                            name: option.str & thing,
                            value: (some (option.str & thing), none int)
                        )
                    await discord.api.createInteractionResponse(i.id, i.token, InteractionResponse(
                        kind: irtAutoCompleteResult,
                        choices: choices
                    ))
    else:
        # Handle interactions normally
```

I went with variant objects over generics in the end so that existing code didn't break