### PR TITLE
Use the latest ws

### DIFF
--- a/dimscord.nimble
+++ b/dimscord.nimble
@@ -7,7 +7,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 1.2.0", "zippy >= 0.2.1", "ws", "regex >= 0.15.0", "libsodium <= 0.6.0", "flatty >= 0.1.2", "jsony >= 1.1.3"
+requires "nim >= 1.2.0", "zippy >= 0.2.1", "ws >= 0.5.0", "regex >= 0.15.0", "libsodium <= 0.6.0", "flatty >= 0.1.2", "jsony >= 1.1.3"
 requires "opussum >= 0.6.0"
 
 task genDoc, "Generates the documentation for dimscord":


### PR DESCRIPTION
When I was using ws@0.4.0, I was getting the following error every time when resuming. 

```
[shard: 0]: Connecting to wss://gateway-us-east1-c.discord.gg/?v=10
[shard: 0]: Attempting to resume
  session_id: 009578068343d3196e5316d56a25a853
  sequence: 1340
[shard: 0]: Sending OP: 6
[shard: 0]: Error occurred in websocket ::
WebSocket Potocol missmatch
```

I tried various solutions, but finally, by using the ws@0.5.0, the error on resume no longer occurs. Now it seems that it is preferable to use the latest ws.

```
[shard: 0]: Shard reconnecting after disconnect...
[shard: 0]: Connecting to wss://gateway-us-east1-c.discord.gg/?v=10                                                                                                            
[shard: 0]: Attempting to resume
  session_id: 0ad7ea10d6cbb4d00ce8e8006c420afe
  sequence: 1924  
[shard: 0]: Sending OP: 6
[shard: 0]: Received 'HELLO' from the gateway.
[shard: 0]: Received event: RESUMED
[shard: 0]: Successfuly resumed. 
```