### PR TITLE
Fix and improve http request with multi-part data

### DIFF
--- a/dimscord/restapi/requester.nim
+++ b/dimscord/restapi/requester.nim
@@ -135,7 +135,7 @@ proc request*(api: RestApi, meth, endpoint: string;
             if mp == nil:
                 resp = await client.request(url, parseEnum[HttpMethod](meth), pl)
             else:
-                resp = await client.post(url, pl, mp)
+                resp = await client.request(url, parseEnum[HttpMethod](meth), pl, multipart=mp)
         except:
             r.processing = false
             raise newException(Exception, getCurrentExceptionMsg())

--- a/dimscord/restapi/requester.nim
+++ b/dimscord/restapi/requester.nim
@@ -132,10 +132,7 @@ proc request*(api: RestApi, meth, endpoint: string;
         ))
 
         try:
-            if mp == nil:
-                resp = await client.request(url, parseEnum[HttpMethod](meth), pl)
-            else:
-                resp = await client.request(url, parseEnum[HttpMethod](meth), pl, multipart=mp)
+            resp = await client.request(url, parseEnum[HttpMethod](meth), pl, multipart=mp)
         except:
             r.processing = false
             raise newException(Exception, getCurrentExceptionMsg())


### PR DESCRIPTION
Currently, only POST is supported for requests that upload files; the Discord API allows files to be attached via `editMessage`, but the dimscord does not allow images to be taken as arguments. Also, `editWebhookMessage` and `editInteractionResponse` take files as an argument, but actually giving files results in a 405 error because the request is made with POST.

Therefore, I have made changes to allow the use of http methods other than POST.

