### PR TITLE
Add components field to createInteractionResponse

### DIFF
--- a/dimscord/restapi/user.nim
+++ b/dimscord/restapi/user.nim
@@ -295,6 +295,10 @@ proc createInteractionResponse*(api: RestApi,
             data = %*(response.data.get)
             if response.data.get.flags.len!=0:
                 data["flags"] = %response.data.get.flags
+            if response.data.get.components.len > 0:
+                data["components"] = newJArray()
+                for component in response.data.get.components:
+                    data["components"] &= %%*component
     of irtAutoCompleteResult:
         let choices = %response.choices.map(
             proc (x: ApplicationCommandOptionChoice): JsonNode =


### PR DESCRIPTION
Processing related to `components` was missing from the `createInteractionResponse` function, so I have been added it.