### PR TITLE
Fix deleteThread event for stable (nim's latest version 1.6.10)

### DIFF
--- a/dimscord/dispatch.nim
+++ b/dimscord/dispatch.nim
@@ -874,6 +874,7 @@ proc threadDelete(s: Shard, data: JsonNode) {.async.} =
         thread = s.cache.guildChannels.getOrDefault(
             data["id"].str,
             GuildChannel(
+                kind: ChannelType(data["type"].getInt(ctGuildText.ord)),
                 id: data["id"].str,
                 guild_id: data["guild_id"].str,
                 parent_id: some data["parent_id"].str,
@@ -884,11 +885,6 @@ proc threadDelete(s: Shard, data: JsonNode) {.async.} =
             Guild(id: data["guild_id"].str)
         )
     var exists = false
-    if ChannelType(data["type"].getInt) in ChannelType.fullSet():
-        thread.kind = ChannelType data["type"].getInt
-    else:
-        thread.kind = ctGuildText
-
     if thread.id in s.cache.guildChannels:
         s.cache.guildChannels.del(thread.id)
         guild.threads.del(thread.id)


### PR DESCRIPTION
Set the kind directly so that we don't run into any discriminant change problems.
This is really only a problem on stable.
This assumes that kind is correct when it can get the channel from cache (Seems like a reasonable assumption)

Tested and it seems to correctly the kind and doesn't break anymore on stable