### PR TITLE
Define SSL so that the user doesn't need to define it themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ proc messageCreate(s: Shard, m: Message) {.event(discord).} =
 # Connect to Discord and run the bot.
 waitFor discord.startSession()
 ```
-Please ensure that when you are running your Discord bot you define `-d:ssl` example: `nim c -r -d:ssl main.nim`, you can use `-d:dimscordDebug`, if you want to debug.
+Please note that you need to define `-d:ssl` if you are importing httpclient before importing dimscord.
+You can use -d:dimscordDebug, if you want to debug.
 
 If you want to use voice then you can use `-d:dimscordVoice`, this requires libsodium, libopus, ffmpeg and optionally youtube-dl (by default)
 

--- a/dimscord.nim
+++ b/dimscord.nim
@@ -68,6 +68,8 @@
 ## - `-d:discordv9` Discord API v9 is used for threads (as in discord's channel type).
 ## - `-d:dimscordVoice` Enables the voice module. Requires libsodium and libopus
 
+{.define: ssl.}
+
 import dimscord/[
     gateway, restapi, constants,
     objects, helpers


### PR DESCRIPTION
Make `ssl` be defined for dimscord so that the user doesn't need to define it for themselves. Fixes the common problem of people forgetting it (annoys the hell out of me :stuck_out_tongue_closed_eyes:)

One thing to note is that this only turns on the define *after* dimscord is imported so the user will still need to define it if they are connecting to HTTPS before importing dimscord e.g.
This will fail
```nim
import httpclient
let client = newHttpclient()

echo client.getContent("https://httpbin.org/ip")
import dimscord
```
And this will fail
```nim
import httpclient
import dimscord
let client = newHttpclient()

echo client.getContent("https://httpbin.org/ip")
```

While this wont
```nim
import dimscord, asyncdispatch, times, options
import httpclient
let client = newHttpclient()

echo client.getContent("https://httpbin.org/ip")
```

While this is a small annoyance, it still will help people in 90% of cases. Tested on `1.6.12` and `devel` and works fine