### PR TITLE
 [WIP] fixes issue 112; add client var to use userland DiscordClient in library code 

### DIFF
--- a/dimscord.nim
+++ b/dimscord.nim
@@ -75,8 +75,10 @@ import dimscord/[
     objects, helpers
 ]
 
-export gateway, restapi, constants, objects, helpers
+export gateway, restapi, constants, helpers
+export objects except client
 
 when defined(dimscordVoice):
     import dimscord/voice
     export voice
+

--- a/dimscord.nim
+++ b/dimscord.nim
@@ -75,8 +75,7 @@ import dimscord/[
     objects, helpers
 ]
 
-export gateway, restapi, constants, helpers
-export objects except client
+export gateway, restapi, constants, helpers, objects
 
 when defined(dimscordVoice):
     import dimscord/voice

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -621,7 +621,6 @@ proc startSession*(discord: DiscordClient,
     # when defined(discordCompress):
     #     query &= "&compress=zlib-stream"
     
-    client = discord
     
     if discord.shards.len == 0:
         log("Starting gateway session.")
@@ -651,6 +650,9 @@ proc startSession*(discord: DiscordClient,
 
         if max_shards.isNone:
             discord.max_shards = info.shards
+        
+        discard getClient(some(discord))
+
 
     for id in 0..discord.max_shards - 1:
         var sid = id
@@ -675,6 +677,8 @@ proc startSession*(discord: DiscordClient,
 
         await s.waitWhenReady()
         if invididualShard: break
+    
+    
 
 proc latency*(s: Shard): int =
     ## Gets the shard's latency ms.

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -620,7 +620,9 @@ proc startSession*(discord: DiscordClient,
 
     # when defined(discordCompress):
     #     query &= "&compress=zlib-stream"
-
+    
+    client = discord
+    
     if discord.shards.len == 0:
         log("Starting gateway session.")
 
@@ -677,3 +679,4 @@ proc startSession*(discord: DiscordClient,
 proc latency*(s: Shard): int =
     ## Gets the shard's latency ms.
     result = int((s.lastHBReceived - s.lastHBTransmit) * 1000)
+

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -650,9 +650,6 @@ proc startSession*(discord: DiscordClient,
 
         if max_shards.isNone:
             discord.max_shards = info.shards
-        
-        discard getClient(some(discord))
-
 
     for id in 0..discord.max_shards - 1:
         var sid = id
@@ -677,8 +674,6 @@ proc startSession*(discord: DiscordClient,
 
         await s.waitWhenReady()
         if invididualShard: break
-    
-    
 
 proc latency*(s: Shard): int =
     ## Gets the shard's latency ms.

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -37,7 +37,6 @@ proc newShard*(id: int, client: DiscordClient): Shard =
         ),
         retry_info: (ms: 1000, attempts: 0)
     )
-# var client*: DiscordClient
 
 proc newDiscordClient*(token: string;
         rest_mode = false;

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -37,7 +37,7 @@ proc newShard*(id: int, client: DiscordClient): Shard =
         ),
         retry_info: (ms: 1000, attempts: 0)
     )
-var client*: DiscordClient
+# var client*: DiscordClient
 
 proc newDiscordClient*(token: string;
         rest_mode = false;

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -37,6 +37,7 @@ proc newShard*(id: int, client: DiscordClient): Shard =
         ),
         retry_info: (ms: 1000, attempts: 0)
     )
+var client*: DiscordClient
 
 proc newDiscordClient*(token: string;
         rest_mode = false;

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -16,7 +16,7 @@ type
         parse*, roles*, users*: seq[string]
         replied_user*: bool
     DiscordEvent* = ref object of RootObj
-        client: DiscordClient
+        client*: DiscordClient
     DiscordClient* = ref object
         api*: RestApi
         events*: Events
@@ -887,7 +887,3 @@ proc `$`*(e: Emoji): string =
             e.name.get("?") & ":" & e.id.get
         else:
             e.name.get("?")
-
-proc client*(e: DiscordEvent): DiscordClient =
-    ## Get current client
-    result = e.client

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -15,6 +15,8 @@ type
         ## For parse: The values should be "roles", "users", "everyone"
         parse*, roles*, users*: seq[string]
         replied_user*: bool
+    DiscordEvent* = ref object of RootObj
+        client: DiscordClient
     DiscordClient* = ref object
         api*: RestApi
         events*: Events
@@ -136,7 +138,7 @@ type
         channel_id*: Option[string]
         message_id*, guild_id*: Option[string]
         fail_if_not_exists*: Option[bool]
-    Message* = ref object
+    Message* = ref object of DiscordEvent
         ## - `sticker_items` == Table[sticker_id, object]
         ## - `reactions` == Table["REACTION_EMOJI", object]
         id*, channel_id*: string
@@ -176,7 +178,7 @@ type
         flags*: set[UserFlags]
         public_flags*: set[UserFlags]
         avatar*, locale*: Option[string]
-    Member* = ref object
+    Member* = ref object of DiscordEvent
         ## - `permissions` Returned in the interaction object.
         ## Be aware that Member.user could be nil in some cases.
         user*: User
@@ -246,12 +248,12 @@ type
         resume_gateway_url*, session_id*: string
         shard*: Option[seq[int]]
         application*: tuple[id: string, flags: set[ApplicationFlags]]
-    DMChannel* = ref object
+    DMChannel* = ref object of DiscordEvent
         id*, last_message_id*: string
         kind*: ChannelType
         recipients*: seq[User]
         messages*: Table[string, Message]
-    GuildChannel* = ref object
+    GuildChannel* = ref object of DiscordEvent
         id*, name*, guild_id*: string
         nsfw*: bool
         parent_id*: Option[string]
@@ -328,7 +330,7 @@ type
     WelcomeChannel* = object
         channel_id*, description*: string
         emoji_id*, emoji_name*: Option[string]
-    Guild* = ref object
+    Guild* = ref object of DiscordEvent
         id*, name*, owner_id*: string
         preferred_locale*: string
         rtc_region*, permissions_new*: Option[string]
@@ -504,7 +506,7 @@ type
         kind*: InteractionType
         user*: User
         member*: Option[Member]
-    Interaction* = object
+    Interaction* = object of DiscordEvent
         ## if `member` is present, then that means the interaction is in guild,
         ## and `user` is therefore not present.
         ##
@@ -885,3 +887,7 @@ proc `$`*(e: Emoji): string =
             e.name.get("?") & ":" & e.id.get
         else:
             e.name.get("?")
+
+proc client*(e: DiscordEvent): DiscordClient =
+    ## Get current client
+    result = e.client

--- a/dimscord/restapi/channel.nim
+++ b/dimscord/restapi/channel.nim
@@ -372,3 +372,147 @@ proc deleteStageInstance*(api: RestApi;
         endpointStageInstances(channel_id),
         audit_reason = reason
     )
+
+proc pin*(m: Message, reason = "") {.async.} =
+    ## Add pinned message.
+    await m.client.api.addChannelMessagePin(m.channel_id, m.id, reason)
+
+proc unpin*(m: Message, reason = "") {.async.} =
+    ## Remove pinned message.
+    await m.client.api.deleteChannelMessagePin(m.channel_id, m.id, reason)
+
+proc pins*(ch: GuildChannel): Future[seq[Message]] {.async.} =
+    ## Get channel pins.
+    ## Note: Due to a limitation of Discord API, `Message` objects do not contain complete `Reaction` data 
+    result = await ch.client.api.getChannelPins(ch.id)
+
+proc edit*(ch: GuildChannel;
+            name, parent_id, topic = none string;
+            rate_limit_per_user = none range[0..21600];
+            bitrate = none range[8000..128000]; user_limit = none range[0..99];
+            position = none int; permission_overwrites = none seq[Overwrite];
+            nsfw = none bool; reason = ""): Future[GuildChannel] {.async.} =
+    ## Modify a guild channel.
+    result = await ch.client.api.editGuildChannel(
+        ch.id, name, parent_id, 
+        topic, rate_limit_per_user, bitrate, 
+        user_limit, position, permission_overwrites, 
+        nsfw, reason
+    )
+
+proc delete*(ch: GuildChannel, reason = "") {.async.} =
+    ## Deletes or closes a channel/thread
+    await ch.client.api.deleteChannel(ch.id, reason)
+
+proc newInvite*(ch: GuildChannel;
+        max_age = 86400; max_uses = 0;
+        temporary, unique = false; target_user = none string;
+        target_user_id, target_application_id = none string;
+        target_type = none InviteTargetType;
+        reason = ""
+): Future[Invite] {.async.} =
+    ## Creates an instant channel invite.
+    result = await ch.client.api.createChannelInvite(
+        ch.id, max_age, max_uses,
+        temporary, unique, target_user,
+        target_user_id, target_application_id,
+        target_type, reason
+    )
+
+# proc delete*(inv: Invite, reason = "") {.async.} =
+#     ## Delete a guild invite.
+#     await inv.client.api.deleteInvite(inv.code, reason)
+
+proc invites*(ch: GuildChannel): Future[seq[Invite]] {.async.} =
+    ## Gets a list of a channel's invites.
+    result = await ch.client.api.getChannelInvites(ch.id)
+
+# proc channel*(g: Guild, channel_id: string): Future[GuildChannel] {.async.} =
+#     ## Gets guild channel by ID.
+#     ## 
+#     ## Fallbacks to discord api if not found inside `Guild` or cache.
+#     
+#     if channel_id in g.channels:
+#         result = g.channels[channel_id]
+#     elif channel_id in g.client.shards[0].cache.guildChannels:
+#         result = g.client.shards[0].cache.guildChannels[channel_id]
+#     else:
+#         let chan = await g.client.api.getChannel(channel_id)
+#         if chan[0].isSome:
+#             result = get chan[0]
+# 
+#     case result.kind
+#     of ctGuildPrivateThread, ctGuildPublicThread:
+#         return result
+# 
+#     raise newException(ValueError, "Channel doesn't exist or is a DM.")
+
+# proc thread*(g: Guild, thread_id: string): Future[Option[GuildChannel]] {.async.} =
+#     ## Gets guild thread by ID.
+#     ## 
+#     ## Fallbacks to discord api if not found inside `Guild` or cache.
+#     if thread_id in g.threads:
+#         result = some g.threads[thread_id]
+#     elif thread_id in g.client.shards[0].cache.guildChannels:
+#         result = some g.client.shards[0].cache.guildChannels[thread_id]
+#     else:
+#         let thr = await g.client.api.getChannel(thread_id)
+#         if thr[0].isSome:
+#             result = thr[0]
+
+# proc dms*(m: Member): Future[Option[DMChannel]] {.async.} =
+#     ## Gets dm channel from a Member
+#     if m.user.isNil: raise newException(ValueError, "User is Nil")
+# 
+#     for v in m.client.shards[0].cache.dmChannels.values:
+#         if (v.kind == ctDirect) and (m.user in v.recipients): # probably wont work for now ?
+#             return some v
+#     
+#     # if nothing was found in the loop we return none T
+#     return none(DMChannel)
+
+# proc dms*(s: Shard, channel_id: string): Future[Option[DMChannel]] {.async.} =
+#     ## Gets dm channel by ID
+#     ## 
+#     ## Fallbacks to discord api if not found inside cache
+#     if channel_id in s.cache.dmChannels:
+#         result = s.cache.dmChannels[channel_id]
+#     else:
+#         let chan = await s.client.api.getChannel(channel_id)
+#         if chan[0].isSome:
+#             result = chan[0]
+
+proc webhooks*(ch: GuildChannel): Future[seq[Webhook]] {.async.} =
+    ## Gets a list of a channel's webhooks.
+    result = await ch.client.api.getChannelWebhooks(ch.id)
+
+# proc delete*(w: Webhook, reason = "") {.async.} =
+#     ## Deletes a webhook.
+#     await w.client.api.deleteWebhook(w.id, reason)
+
+# proc edit*(w: Webhook, name = w.name, avatar = w.avatar, reason = "") {.async.} =
+#     await w.client.api.editWebhook(w.id, name, avatar, some w.channel_id, reason)
+
+proc newThread*(ch: GuildChannel;
+    name: string;
+    auto_archive_duration = 60;
+    kind = ctGuildPrivateThread;
+    invitable = none bool;
+    reason = ""
+): Future[GuildChannel] {.async.} =
+    ## Starts a new thread.
+    ## /!\ Can only accept ... as `kind`
+    result = ch.client.api.startThreadWithoutMessage(ch.id, name, auto_archive_duration, kind, invitable, reason)
+
+proc createStage*(ch: GuildChannel, topic: string, reason = "", privacy = int plGuildOnly): Future[StageInstance] {.async.} =
+    ## Create a stage instance.
+    ## 
+    result = await ch.client.api.createStageInstance(ch.id, topic, privacy, reason)
+
+# proc edit*(si: StageInstance, topic = si.topic, privacy = si.privacy_level, reason = ""): Future[StageInstance] {.async.} =
+#     ## Modify a stage instance.
+#     result = await si.client.api.editStageInstance(si.channel_id, topic, privacy, reason)
+
+# proc delete*(si: StageInstance, reason = "") {.async.} =
+#     ## Delete the stage instance.
+#     await si.client.api.deleteStageInstance(si.channel_id, reason)

--- a/dimscord/restapi/guild.nim
+++ b/dimscord/restapi/guild.nim
@@ -1,4 +1,4 @@
-import asyncdispatch, json, options
+import asyncdispatch, json, options, tables
 import ../objects, ../constants, ../helpers
 import sequtils, strutils, jsony
 import requester
@@ -972,23 +972,21 @@ proc prune*(g: Guild;
         include_roles: seq[string] = @[];
         compute_prune_count = true) {.async.} =
     ## Begins a guild prune.
-    await g.client.api.beginGuildPrune(g.id, days, include_roles, compute_prune_count)
+    await getClient().api.beginGuildPrune(g.id, days, include_roles, compute_prune_count)
 
 proc pruneCount*(g: Guild, days: int): Future[int] {.async.} =
     ## Gets the prune count.
-    result = await g.client.api.getGuildPruneCount(g.id, days)
+    result = await getClient().api.getGuildPruneCount(g.id, days)
 
 proc editMFA(g: Guild, lvl: MFALevel): Future[MFALevel] {.async.} =
     ## Modify Guild MFA Level, requiring guild ownership.
-    if g.owner_id != g.client.shards[0].user.id:
-        raise newException(ValueError, "Bot is not server owner, cannot change MFA level!")
-    result = await g.client.api.editGuildMFALevel(g.id, lvl)
+    
+    result = await getClient().api.editGuildMFALevel(g.id, lvl)
 
 proc delete*(g: Guild) {.async.} =
     ## Deletes a guild. Requires guild ownership.
-    if g.owner_id != g.client.shards[0].user.id:
-        raise newException(ValueError, "Bot is not server owner, cannot change MFA level!")
-    await g.client.api.deleteGuild(g.id)
+
+    await getClient().api.deleteGuild(g.id)
 
 proc edit*(g: Guild;
         name, description, region, afk_channel_id, icon = none string;
@@ -1009,8 +1007,8 @@ proc edit*(g: Guild;
     ## 
     ## Read more at: 
     ## https://discord.com/developers/docs/resources/guild#modify-guild
-    result = g.client.api.editGuild(    
-        name, description, region, afk_channel_id, icon,
+    result = await getClient().api.editGuild(    
+        g.id, name, description, region, afk_channel_id, icon,
         discovery_splash, owner_id, splash, banner,
         system_channel_id, rules_channel_id,
         preferred_locale, public_updates_channel_id,
@@ -1022,15 +1020,18 @@ proc edit*(g: Guild;
 
 proc audits*(g: Guild; 
         user_id, before = "", action_type = -1;
-        limit: range[1..100 = 50]
+        limit: range[1..100] = 50
 ): Future[AuditLog] {.async.} =
     ## Get guild audit logs. The maximum limit is 100.
-    result = await g.client.api.getGuildAuditLogs(g.id, user_id, before, action_type, limit)
+    result = await getClient().api.getGuildAuditLogs(g.id, user_id, before, action_type, limit)
 
+# +[requires `guild_id`]
 # proc delete*(r: Role) {.async.} =
 #    ## Deletes a guild role.
-#    await r.client.api.deleteGuildRole(r.guild_id, r.id)
+#    await getClient().api.deleteGuildRole(r.guild_id, r.id)
 
+
+# +[requires `guild_id`]
 # proc edit*(r: Role;
 #         name = none string;
 #         icon, unicode_emoji = none string;
@@ -1039,7 +1040,7 @@ proc audits*(g: Guild;
 #         reason = ""
 # ): Future[Role] {.async.} =
 #     ## Modifies a guild role.
-#     result = await r.client.api.editGuildRole(
+#     result = await getClient().api.editGuildRole(
 #         r.guild_id, r.id,
 #         name, icon, unicode_emoji,
 #         permissions, color,
@@ -1049,13 +1050,14 @@ proc audits*(g: Guild;
 
 proc invites*(g: Guild): Future[seq[InviteMetadata]] {.async.} =
     ## Gets guild invites.
-    result = await g.client.api.getGuildInvites(g.id)
+    result = await getClient().api.getGuildInvites(g.id)
 
 proc vanity*(g: Guild): Future[tuple[code: Option[string], uses: int]] {.async.} =
     ## Get the guild vanity url. Requires the MANAGE_GUILD permission. 
     ## `code` will be null if a vanity url for the guild is not set.
-    result = g.client.api.getGuildVanityUrl(g.id)
+    result = await getClient().api.getGuildVanityUrl(g.id)
 
+# +[requires `guild_id`]
 # proc edit*(mb: Member;
 #         nick, channel_id, communication_disabled_until = none string;
 #         roles = none seq[string];
@@ -1065,150 +1067,158 @@ proc vanity*(g: Guild): Future[tuple[code: Option[string], uses: int]] {.async.}
 #     ## Modifies a guild member
 #     ## Note:
 #     ## - `communication_disabled_until` - ISO8601 timestamp :: [<=28 days]
-#     await mb.client.api.editGuildMember(
+#     await getClient().api.editGuildMember(
 #         mb.guild_id, mb.user.id, nick, channel_id, communication_disabled_until,
 #         roles, mute, deaf, reason
 #     )
 
+# +[requires `guild_id`]
 # proc kick*(mb: Member, reason = "") {.async.} =
 #     ## Removes a guild member.
-#     await mb.client.api.removeGuildMember(mb.guild_id, mb.user.id, reason)
+#     await getClient().api.removeGuildMember(mb.guild_id, mb.user.id, reason)
 
+# +[requires `guild_id`]
 # proc banStatus*(mb: Member): Future[GuildBan] {.async.} =
 #     ## Gets guild ban.
-#     mb.client.api.getGuildBan(mb.guild_id, mb.user.id)
+#     getClient().api.getGuildBan(mb.guild_id, mb.user.id)
 
 proc bans*(g: Guild): Future[seq[GuildBan]] {.async.} =
     ## Gets all the guild bans.
-    result = await g.client.api.getGuildBans(g.id)
+    result = await getClient().api.getGuildBans(g.id)
 
+# +[requires `guild_id`]
 # proc ban*(mb: Member, purge_range: range[0..7] = 0; reason = "") {.async.} =
 #     ## Creates a guild ban.
-#     await mb.client.api.createGuildBan(mb.guild_id, mb.user.id, purge_range, reason)
+#     await getClient().api.createGuildBan(mb.guild_id, mb.user.id, purge_range, reason)
 
+# +[requires `guild_id`]
 # proc unban*(mb: Member, reason = "") {.async.} =
 #     ## Removes a guild ban.
-#     await mb.client.api.removeGuildBan(mb.guild_id, mb.user.id, reason)
+#     await getClient().api.removeGuildBan(mb.guild_id, mb.user.id, reason)
 
 proc integrations*(g: Guild): Future[seq[Integration]] {.async.} =
     ## Gets a list of guild integrations.
-    result = await g.client.api.getGuildIntegrations(g.id)
+    result = await getClient().api.getGuildIntegrations(g.id)
 
 proc webhooks*(g: Guild): Future[seq[Webhook]] {.async.} =
     ## Gets a list of a channel's webhooks.
-    result = await g.client.api.getGuildWebhooks(g.id)
+    result = await getClient().api.getGuildWebhooks(g.id)
 
-# proc delete*(integ: Integration, reason = "") {.async.} =
-#     ## Deletes a guild integration.
-#     await integ.client.api.deleteGuildIntegration(integ.id, reason)
+proc delete*(integ: Integration, reason = "") {.async.} =
+    ## Deletes a guild integration.
+    await getClient().api.deleteGuildIntegration(integ.id, reason)
 
 proc preview*(g: Guild): Future[GuildPreview] {.async.} =
     ## Gets guild preview.
-    result = await g.client.api.getGuildPreview(g.id)
+    result = await getClient().api.getGuildPreview(g.id)
 
 proc search*(g: Guild, query = "", limit: range[1..1000] = 1): Future[seq[Member]] {.async.} =
     ## Search for guild members.
-    result = await g.client.api.searchGuildMembers(g.id, query, limit)
+    result = await getClient().api.searchGuildMembers(g.id, query, limit)
 
+# +[requires `guild_id`]
 # proc edit*(em: Emoji, name = none string;
 #         roles = none seq[string];
 #         reason = ""
 # ): Future[Emoji] {.async.} =
 #     ## Modifies a guild emoji.
-#     result = await em.client.api.editGuildEmoji(em.guild_id, em.id, name, roles, reason)
+#     result = await getClient().api.editGuildEmoji(em.guild_id, em.id, name, roles, reason)
 
+# +[requires `guild_id`]
 # proc delete*(em: Emoji, reason = "") {.async.} =
 #     ## Deletes a guild emoji.
-#     result = await em.client.api.deleteGuildEmoji(em.guild_id, em.id, reason)
+#     result = await getClient().api.deleteGuildEmoji(em.guild_id, em.id, reason)
 
 proc regions*(g: Guild): Future[seq[VoiceRegion]] {.async.} =
     ## Gets a guild's voice regions.
-    result = await g.client.api.getGuildVoiceRegions(g.id)
+    result = await getClient().api.getGuildVoiceRegions(g.id)
 
-# proc edit*(sk: Sticker;
-#         name, desc, tags = none string;
-#         reason = ""
-# ): Future[Sticker] {.async.} =
-#     ## Modify a guild sticker.
-#     if sk.guild_id.isNone:
-#         raise newException(ValueError, "This sticker doesn't belong to any guilds !")
-#     result = await sk.client.api.editGuildSticker(sk.get(guild_id), sk.id, name, desc, tags, reason)
 
-# proc delete*(sk: Sticker, reason = ""): Future[Sticker] {.async.} =
-#     ## Deletes a guild sticker.
-#     if sk.guild_id.isNone:
-#         raise newException(ValueError, "This sticker doesn't belong to any guilds !")
-#     result = await sk.client.api.deleteGuildSticker(sk.get(guild_id), sk.id, reason)
+proc edit*(sk: Sticker;
+        name, desc, tags = none string;
+        reason = ""
+): Future[Sticker] {.async.} =
+    ## Modify a guild sticker.
+    if sk.guild_id.isNone:
+        raise newException(CatchableError, "This sticker doesn't belong to any guilds !")
+    result = await getClient().api.editGuildSticker(sk.guild_id.get, sk.id, name, desc, tags, reason)
+
+proc delete*(sk: Sticker, reason = ""): Future[Sticker] {.async.} =
+    ## Deletes a guild sticker.
+    if sk.guild_id.isNone:
+        raise newException(CatchableError, "This sticker doesn't belong to any guilds !")
+    result = await getClient().api.deleteGuildSticker(sk.guild_id.get, sk.id, reason)
 
 proc scheduledEvent*(g: Guild;
         event_id: string, with_user_count = false
 ): Future[GuildScheduledEvent] {.async.} =
     ## Get a scheduled event in a guild.
-    result = await g.client.api.getScheduledEvent(g.id, event_id, with_user_count)
+    result = await getClient().api.getScheduledEvent(g.id, event_id, with_user_count)
 
 proc scheduledEvents*(g: Guild): Future[seq[GuildScheduledEvent]] {.async.} =
     ## Get all scheduled events in a guild.
-    result = await g.client.api.getScheduledEvents(g.id)
+    result = await getClient().api.getScheduledEvents(g.id)
 
-# proc edit*(gse: GuildScheduledEvent;
-#         name, start_time, image = none string;
-#         channel_id, end_time, desc = none string;
-#         privacy_level = none GuildScheduledEventPrivacyLevel;
-#         entity_type = none EntityType;
-#         entity_metadata = none EntityMetadata;
-#         status = none GuildScheduledEventStatus;
-#         reason = ""
-# ): Future[GuildScheduledEvent] {.async.} =
-#     ## Update a scheduled event in a guild.
-#     ## Read more: https://discord.com/developers/docs/resources/guild-scheduled-event#modify-guild-scheduled-event-json-params
-#     result = await gse.client.api.editScheduledEvent(
-#         gse.guild_id, gse.id, name;
-#         start_time, image,
-#         channel_id, end_time, desc,
-#         privacy_level, entity_type,
-#         entity_metadata, status,
-#         reason
-#     )
+proc edit*(gse: GuildScheduledEvent;
+        name, start_time, image = none string;
+        channel_id, end_time, desc = none string;
+        privacy_level = none GuildScheduledEventPrivacyLevel;
+        entity_type = none EntityType;
+        entity_metadata = none EntityMetadata;
+        status = none GuildScheduledEventStatus;
+        reason = ""
+): Future[GuildScheduledEvent] {.async.} =
+    ## Update a scheduled event in a guild.
+    ## Read more: https://discord.com/developers/docs/resources/guild-scheduled-event#modify-guild-scheduled-event-json-params
+    result = await getClient().api.editScheduledEvent(
+        gse.guild_id, gse.id, name,
+        start_time, image,
+        channel_id, end_time, desc,
+        privacy_level, entity_type,
+        entity_metadata, status,
+        reason
+    )
 
-# proc delete*(gse: GuildScheduledEvent, reason = "") {.async.} =
-#     ## Delete a scheduled event in guild.
-#     result = await gse.client.api.deleteScheduledEvent(gse.guild_id, gse.id, reason)
+proc delete*(gse: GuildScheduledEvent, reason = "") {.async.} =
+   ## Delete a scheduled event in guild.
+   await getClient().api.deleteScheduledEvent(gse.guild_id, gse.id, reason)
 
-# proc subscribers*(gse: GuildScheduledEvent;
-#         limit = 100, with_member = false;
-#         before, after = ""
-# ): Future[seq[GuildScheduledEventUser]] {.async.} =
-#     ## Gets the users and/or members that were subscribed to the scheduled event.
-#     result = await gse.client.api.getScheduledEventUsers(gse.guild_id, gse.id, limit, with_member, before, after)
+proc subscribers*(gse: GuildScheduledEvent;
+        limit = 100, with_member = false;
+        before, after = ""
+): Future[seq[GuildScheduledEventUser]] {.async.} =
+    ## Gets the users and/or members that were subscribed to the scheduled event.
+    await getClient().api.getScheduledEventUsers(gse.guild_id, gse.id, limit, with_member, before, after)
 
-# proc rules*(g: Guild): Future[seq[AutoModerationRule]] {.async.} =
-#     ## Get a Guild's current AutoMod Rules
-#     result = await g.client.api.getAutoModerationRules(g.id)
+proc rules*(g: Guild): Future[seq[AutoModerationRule]] {.async.} =
+    ## Get a Guild's current AutoMod Rules
+    result = await getClient().api.getAutoModerationRules(g.id)
 
-# proc rule*(g: Guild, rule_id: string): Future[AutoModerationRule] {.async.} =
-#     ## Get a Guild's specific AutoMod Rule
-#     result = await g.client.api.getAutoModerationRule(g.id, rule_id)
+proc rule*(g: Guild, rule_id: string): Future[AutoModerationRule] {.async.} =
+    ## Get a Guild's specific AutoMod Rule
+    result = await getClient().api.getAutoModerationRule(g.id, rule_id)
 
-# proc delete*(amr: AutoModerationRule) {.async.} =
-#     ## deletes automod rule
-#     await amr.client.api.deleteAutoModerationRule(amr.guild_id, amr.id)
+proc delete*(amr: AutoModerationRule) {.async.} =
+    ## deletes automod rule
+    await getClient().api.deleteAutoModerationRule(amr.guild_id, amr.id)
 
-# proc edit*(amr: AutoModerationRule;
-#     guild_id, rule_id: string; event_type = none int;
-#     name = none string; trigger_type = none ModerationTriggerType;
-#     trigger_metadata = none tuple[
-#         keyword_filter: seq[string],
-#         presets: seq[int]
-#     ];
-#     actions = none seq[ModerationAction]; enabled = none bool;
-#     exempt_roles, exempt_channels = none seq[string];
-#     reason = ""
-# ): Future[AutoModerationRule] {.async.} =
-#     ## Edits an automod rule.
-#     ## `event_type` is gonna be 1 for SEND_MESSAGE
-#     result = await amr.client.api.editAutoModerationRule(
-#         amr.guild_id, amr.id, event_type, 
-#         name, trigger_metadata, actions, 
-#         enabled, exempt_roles, exempt_channels, 
-#         reason 
-#     )
+proc edit*(amr: AutoModerationRule;
+    event_type = none int, name = none string; 
+    trigger_type = none ModerationTriggerType;
+    trigger_metadata = none tuple[
+        keyword_filter: seq[string],
+        presets: seq[int]
+    ];
+    actions = none seq[ModerationAction]; enabled = none bool;
+    exempt_roles, exempt_channels = none seq[string];
+    reason = ""
+): Future[AutoModerationRule] {.async.} =
+    ## Edits an automod rule.
+    ## `event_type` is gonna be 1 for SEND_MESSAGE
+    result = await getClient().api.editAutoModerationRule(
+        amr.guild_id, amr.id, event_type, 
+        name, trigger_type,
+        trigger_metadata, actions, 
+        enabled, exempt_roles, exempt_channels, 
+        reason 
+    )

--- a/dimscord/restapi/message.nim
+++ b/dimscord/restapi/message.nim
@@ -97,32 +97,6 @@ proc sendMessage*(api: RestApi, channel_id: string;
         mp = mpd
     )).newMessage
 
-proc reply*(m: Message, content: string = "";
-            embeds: seq[Embed] = @[]; 
-            attachments: seq[Attachment] = @[];
-            components: seq[MessageComponent] = @[]; 
-            files: seq[DiscordFile] = @[];
-            stickers: seq[string] = @[];
-            ping = false): Future[Message] {.async.} =
-    ## Replies to a Message.
-    ## (?) - use `ping = true` in order to ping the message on Discord.
-
-    let msg_ref = block:
-        if not ping: 
-            none MessageReference 
-        else: 
-            some MessageReference(message_id: some m.id, failIfNotExists: some false)
-
-    result = await client.api.sendMessage(
-        channel_id = m.channel_id,
-        content = content,
-        embeds = embeds,
-        sticker_ids = stickers,
-        attachments = attachments,
-        message_reference = msg_ref,
-        files = files
-    )
-
 proc editMessage*(api: RestApi, channel_id, message_id: string;
         content = ""; tts = false; flags = none int;
         files = newSeq[DiscordFile]();
@@ -204,21 +178,6 @@ proc editMessage*(api: RestApi, channel_id, message_id: string;
         mp = mpd
     )).newMessage
 
-proc edit*(m: Message, content = m.content;
-           embeds = m.embeds;
-           attachments = m.attachments): Future[Message] {.async.} =
-    ## Edits a Message non-destructively.
-    ## - Using `edit` for ephemeral messages results in an "Unknown Message" error !
-
-
-    result = await client.api.editMessage(
-        channel_id = m.channel_id,
-        message_id = m.id,
-        content = content,
-        embeds = embeds,
-        attachments = attachments
-    )
-
 proc crosspostMessage*(api: RestApi;
         channel_id, message_id: string): Future[Message] {.async.} =
     ## Crosspost channel message aka publish messages into news channels.
@@ -235,10 +194,6 @@ proc deleteMessage*(api: RestApi, channel_id, message_id: string;
         endpointChannelMessages(channel_id, message_id),
         audit_reason = reason
     )
-
-proc delete*(m: Message) {.async.} =
-    ## Deletes a Message.
-    await client.api.deleteMessage(m.channel_id, m.id)
 
 proc getChannelMessages*(api: RestApi, channel_id: string;
         around, before, after = "";
@@ -292,12 +247,6 @@ proc addMessageReaction*(api: RestApi,
         endpointReactions(channel_id, message_id, e=emj, uid="@me")
     )
 
-proc react*(m: Message, emoji: string) {.async.} =
-    ## Add a reaction to a Message
-    ## 
-    ## - `emoji` Example: '👀', '💩', `likethis:123456789012345678`
-    await client.api.addMessageReaction(m.channel_id, m.id, emoji)
-    
 proc deleteMessageReaction*(api: RestApi,
         channel_id, message_id, emoji: string;
         user_id = "@me") {.async.} =
@@ -311,10 +260,6 @@ proc deleteMessageReaction*(api: RestApi,
         endpointReactions(channel_id, message_id, e=emj, uid=user_id)
     )
 
-proc unreact*(m: Message, emoji: string, user_id = "@me") {.async.} =
-    ## Deletes the user's or the bot's message reaction to a Discord message.
-    await client.api.deleteMessageReaction(m.channel_id, m.id, user_id)
-
 proc deleteMessageReactionEmoji*(api: RestApi,
         channel_id, message_id, emoji: string) {.async.} =
     ## Deletes all the reactions for emoji.
@@ -322,10 +267,6 @@ proc deleteMessageReactionEmoji*(api: RestApi,
         "DELETE",
         endpointReactions(channel_id, message_id, emoji)
     )
-
-proc unreactAll*(m: Message, emoji: string) {.async.} =
-    ## Deletes all the reactions for emoji.
-    await client.api.deleteMessageReactionEmoji(m.channel_id, m.id, emoji)
     
 proc getMessageReactions*(api: RestApi,
         channel_id, message_id, emoji: string;
@@ -357,10 +298,6 @@ proc deleteAllMessageReactions*(api: RestApi,
         "DELETE",
         endpointReactions(channel_id, message_id)
     )
-
-proc clear*(m: Message) {.async.} =
-    ## Remove all message reactions.
-    await client.api.deleteAllMessageReactions(m.channel_id, m.id)
 
 proc executeWebhook*(api: RestApi, webhook_id, webhook_token: string;
         wait = true; thread_id = none string;
@@ -479,30 +416,6 @@ proc createFollowupMessage*(api: RestApi,
         flags = flags,
         wait = true
     ))
-
-
-proc followup*(i: Interaction;
-            content = "";
-            embeds: seq[Embed] = @[];
-            components: seq[MessageComponent] = @[];
-            attachments: seq[Attachment] = @[];
-            files: seq[DiscordFile] = @[];
-            application_id = i.application_id;
-            token = i.token;              
-            ephemeral = false): Future[Message] {.async.} =
-    ## Follow-up to an Interaction.
-    ## - Use this function when sending messages to acknowledged Interactions.
-
-    result = await client.api.createFollowupMessage(
-        application_id = application_id,
-        interaction_token = token,
-        content = content,
-        attachments = attachments,
-        embeds = embeds,
-        components = components,
-        files = files,
-        flags = if ephemeral: some (1 shl 6) else: none int
-    )
 
 proc editWebhookMessage*(api: RestApi;
         webhook_id, webhook_token, message_id: string;
@@ -627,10 +540,6 @@ proc getInteractionResponse*(
         application_id, interaction_token, message_id
     )
 
-proc fetchResponse*(i: Interaction, id = "@original"): Future[Message] {.async.} =
-    ## Get the response (Message) to an Interaction
-    result = await client.api.getWebhookMessage(i.application_id, i.token, id)
-
 proc deleteWebhookMessage*(api: RestApi;
         webhook_id, webhook_token, message_id: string;
         thread_id = none string) {.async.} =
@@ -645,10 +554,6 @@ proc deleteInteractionResponse*(api: RestApi;
     await api.deleteWebhookMessage(
         application_id, interaction_token, message_id
     )
-
-proc delete*(i: Interaction) {.async.} =
-    ## Deletes an Interaction Response or Followup Message
-    await client.api.deleteInteractionResponse(i.application_id, i.token, "@original")
 
 proc executeSlackWebhook*(api: RestApi, webhook_id, token: string;
         wait = true;thread_id = none string): Future[Option[Message]] {.async.} =
@@ -746,3 +651,177 @@ proc startThreadWithMessage*(api: RestApi,
         }),
         audit_reason = reason
     )).newGuildChannel
+
+proc send*(ch: GuildChannel;
+        content = ""; tts = false;
+        nonce: Option[string] or Option[int] = none(int);
+        files: seq[DiscordFile] = @[];
+        embeds: seq[Embed] = @[]; 
+        attachments: seq[Attachment] = @[];
+        allowed_mentions = none AllowedMentions;
+        message_reference = none MessageReference;
+        components = newSeq[MessageComponent]();
+        sticker_ids = newSeq[string]()
+): Future[Message] {.async.} =
+    ## Sends a Discord message.
+    ## - `nonce` This can be used for optimistic message sending
+    result = await ch.client.api.sendMessage(
+        ch.id, content, tts,
+        nonce, files, embeds,
+        attachments, allowed_mentions, message_reference,
+        components, sticker_ids
+    )
+
+proc reply*(m: Message, content: string = "";
+            embeds: seq[Embed] = @[]; 
+            attachments: seq[Attachment] = @[];
+            components: seq[MessageComponent] = @[]; 
+            files: seq[DiscordFile] = @[];
+            stickers: seq[string] = @[];
+            ping = false): Future[Message] {.async.} =
+    ## Replies to a Message.
+    ## (?) - use `ping = true` in order to ping the message on Discord.
+
+    let msg_ref = block:
+        if not ping: 
+            none MessageReference 
+        else: 
+            some MessageReference(message_id: some m.id, failIfNotExists: some false)
+
+    result = await client.api.sendMessage(
+        channel_id = m.channel_id,
+        content = content,
+        embeds = embeds,
+        sticker_ids = stickers,
+        attachments = attachments,
+        message_reference = msg_ref,
+        files = files
+    )
+
+proc edit*(m: Message;
+        content = m.content;
+        embeds = m.embeds;
+        attachments = m.attachments;
+        tts = m.tts;
+        flags = m.flags;
+        ): Future[Message] {.async.} =
+    ## Edits a Message non-destructively.
+    ## - Using `edit` for ephemeral messages results in an "Unknown Message" error !
+
+
+    result = await client.api.editMessage(
+        channel_id = m.channel_id,
+        message_id = m.id,
+        content = content,
+        embeds = embeds,
+        attachments = attachments,
+        tts = tts, flags = flags
+    )
+    
+proc delete*(m: Message, reason = "") {.async.} =
+    ## Deletes a Message.
+    await m.client.api.deleteMessage(m.channel_id, m.id, reason)
+
+proc react*(m: Message, emoji: string) {.async.} =
+    ## Add a reaction to a Message
+    ## 
+    ## - `emoji` Example: '👀', '💩', `likethis:123456789012345678`
+    await client.api.addMessageReaction(m.channel_id, m.id, emoji)
+
+proc unreact*(m: Message, emoji: string, user_id = "@me") {.async.} =
+    ## Deletes the user's or the bot's message reaction to a Discord message.
+    await client.api.deleteMessageReaction(m.channel_id, m.id, user_id)
+
+proc unreactAll*(m: Message, emoji: string) {.async.} =
+    ## Deletes all the reactions for emoji.
+    await client.api.deleteMessageReactionEmoji(m.channel_id, m.id, emoji)
+
+proc reactions(m: Message, emoji: string;
+        before, after = "";
+        limit: range[1..100] = 25
+): Future[seq[User]] {.async.} =
+    ## Get all user message reactions on the emoji provided.
+    result = m.client.api.getMessageReactions(
+        m.channel_id, m.id, emoji,
+        before, after, limit
+    )
+proc clear*(m: Message) {.async.} =
+    ## Remove all message reactions.
+    await client.api.deleteAllMessageReactions(m.channel_id, m.id)
+
+proc followup*(i: Interaction;
+            content = "";
+            embeds: seq[Embed] = @[];
+            components: seq[MessageComponent] = @[];
+            attachments: seq[Attachment] = @[];
+            files: seq[DiscordFile] = @[];
+            application_id = i.application_id;
+            token = i.token;              
+            ephemeral = false): Future[Message] {.async.} =
+    ## Follow-up to an Interaction.
+    ## - Use this function when sending messages to acknowledged Interactions.
+
+    result = await client.api.createFollowupMessage(
+        application_id = application_id,
+        interaction_token = token,
+        content = content,
+        attachments = attachments,
+        embeds = embeds,
+        components = components,
+        files = files,
+        flags = if ephemeral: some (1 shl 6) else: none int
+    )
+
+proc edit*(i: Interaction, message_id = "@original";
+        content = none string;
+        embeds = newSeq[Embed]();
+        allowed_mentions = none AllowedMentions;
+        attachments = newSeq[Attachment]();
+        files = newSeq[DiscordFile]();
+        components = newSeq[MessageComponent]()
+): Future[Message] {.async.} =
+    ## Modifies interaction response
+    ## You can actually use this to modify original interaction or followup message.
+    ##
+    ## - `message_id` can be `@original`
+    result = await i.client.api.editWebhookMessage(
+        i.id, i.token, message_id,
+        content = content,
+        embeds = embeds,
+        allowed_mentions = allowed_mentions,
+        attachments = attachments,
+        files = files,
+        components = components,
+    )
+
+proc fetchResponse*(i: Interaction, message_id = "@original"): Future[Message] {.async.} =
+    ## Get the response (Message) to an Interaction
+    result = await client.api.getWebhookMessage(i.application_id, i.token, message_id)
+
+proc delete*(i: Interaction, message_id = "@original") {.async.} =
+    ## Deletes an Interaction Response or Followup Message
+    await i.client.api.deleteInteractionResponse(i.application_id, i.token, message_id)
+
+proc leave*(ch: GuildChannel) {.async.} =
+    ## Leave thread.
+    if ch.kind == ctGuildPublicThread or ctGuildPrivateThread:
+        await ch.client.api.leaveThread(ch.id)
+    else:
+        raise newException(CatchableError, "Channel is not a thread !")
+
+proc join*(ch: GuildChannel) {.async.} =
+    ## Join thread.
+    if ch.kind == ctGuildPublicThread or ctGuildPrivateThread:
+        await ch.client.api.joinThread(ch.id)
+    else:
+        raise newException(CatchableError, "Channel is not a thread !")
+
+proc startThread*(m: Message, name: string; 
+    auto_archive_duration: range[60..10080], reason = ""
+): Future[GuildChannel] {.async.} =
+    ## Starts a public thread.
+    ## - `auto_archive_duration` Duration in mins. Can set to: 60 1440 4320 10080
+    result = await m.client.api.startThreadWithMessage(
+        m.channel_id, m.id, name,
+        auto_archive_duration, reason
+    )


### PR DESCRIPTION
This PR modifies `startSession` to assign a reference to a variable that points to a user populated `DiscordClient` so that we can use it in library code, this allows us:
- to introduce procs like `defer` and other useful sugar that doesn't need the `discord.api` prefix
- to (?) potentially refactor a bunch of procs that would not need the prefix either

New sugary procs are noticable by their short naming scheme.

What we need to complete this PR:
- [ ] tests that include the added procs
- [ ] documenting them
- [ ] decide if this is the design that we really want
