### PR TITLE
Bubble the exception up instead of creating a new one

### DIFF
--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -355,7 +355,7 @@ proc reconnect(s: Shard) {.async.} =
         await s.identify()
     else:
         await s.resume()
- 
+
 proc disconnect*(s: Shard, should_reconnect = true) {.async.} =
     ## Disconnects a shard.
     if s.sockClosed: return
@@ -381,11 +381,11 @@ proc disconnect*(s: Shard, should_reconnect = true) {.async.} =
 proc heartbeat(s: Shard, requested = false) {.async.} =
     if s.sockClosed or s.resuming: return
 
-    if not requested: 
+    if not requested:
         if not s.hbAck:
             s.logShard("A zombied connection was detected.")
             await s.disconnect(should_reconnect = true)
-            return 
+            return
         s.hbAck = false
     s.logShard("Sending heartbeat.")
 
@@ -559,13 +559,13 @@ proc startSession(s: Shard, url, query: string) {.async.} =
         s.logShard("Socket state:\n  ->  " & $s.connection[])
     except:
         s.stop = true
-        raise newException(Exception, getCurrentExceptionMsg())
+        raise
 
     try:
         await s.handleSocketMessage()
     except:
         if not getCurrentExceptionMsg()[0].isAlphaNumeric: return
-        raise newException(Exception, getCurrentExceptionMsg())
+        raise
 
 proc startSession*(discord: DiscordClient,
             autoreconnect = true;
@@ -577,11 +577,11 @@ proc startSession*(discord: DiscordClient,
             cache_users, cache_guilds, guild_subscriptions = true;
             cache_guild_channels, cache_dm_channels = true) {.async.} =
     ## Connects the client to Discord via gateway.
-    ## 
+    ##
     ## - `gateway_intents` Allows you to subscribe to pre-defined events.
     ##    **NOTE:** When not specified this will default to:
     ##    `giGuilds, giGuildMessages, giDirectMessages, giGuildVoiceStates, giMessageContent`
-    ## 
+    ##
     ## - `large_threshold` The number that would be considered a large guild (50-250).
     ## - `guild_subscriptions` Whether or not to receive presence_update, typing_start events.
     ## - `autoreconnect` Whether the client should reconnect whenever a network error occurs.
@@ -631,7 +631,7 @@ proc startSession*(discord: DiscordClient,
                 log("A network error has been detected.")
                 return
 
-        log("Successfully retrived gateway information from Discord:" & 
+        log("Successfully retrived gateway information from Discord:" &
             "\n  shards: $1,\n  session_start_limit: $2" % [
             $info.shards,
             $info.session_start_limit

--- a/dimscord/restapi/requester.nim
+++ b/dimscord/restapi/requester.nim
@@ -135,7 +135,7 @@ proc request*(api: RestApi, meth, endpoint: string;
             resp = await client.request(url, parseEnum[HttpMethod](meth), pl, multipart=mp)
         except:
             r.processing = false
-            raise newException(Exception, getCurrentExceptionMsg())
+            raise
 
         log("Got response.")
 
@@ -185,7 +185,7 @@ proc request*(api: RestApi, meth, endpoint: string;
                     invalid_requests += 1
 
                     error = fin & "You are being rate-limited."
-                    var retry: int 
+                    var retry: int
 
                     if api.restVersion >= 8:
                         retry = data["retry_after"].getInt * 1000

--- a/dimscord/voice.nim
+++ b/dimscord/voice.nim
@@ -480,7 +480,7 @@ proc startSession*(v: VoiceClient) {.async.} =
         logVoice "Socket opened."
     except:
         v.stopped = true
-        raise getCurrentException()
+        raise
     try:
         # logVoice "handlong socket" ???
         await v.handleSocketMessage()
@@ -518,14 +518,14 @@ proc sendAudioPacket*(v: VoiceClient, data: string) {.async.} =
     header.addUint16(toBigEndian uint16 v.sequence)
     header.addUint32(toBigEndian uint32 v.time)
     header.addUint32(toBigEndian uint32(v.ssrc))
-    let 
+    let
         nonce = v.makeNonce(header)
         encrypted = crypto_secretbox_easy(v.secret_key, data, nonce)
 
     var packet = newStringOfCap(header.len + encrypted.len)
     packet &= header
     packet &= encrypted
-    
+
     if v.encryptMode != Normal:
         packet &= nonce
     while v.paused:
@@ -701,11 +701,11 @@ proc playYTDL*(v: VoiceClient, url: string; command = "youtube-dl") {.async.} =
     # doAssert exitCode == 0, "An error occurred:\n" & output
     let first = output.split("\n")[0]
     let sec = output.split("\n")[1]
-    
+
     if not first.startsWith("http") and not sec.startsWith("http"):
         raise newException(Exception, "error occurred:\n\n" & output)
 
-    if not sec.startsWith("http"): 
+    if not sec.startsWith("http"):
         await v.playFFMPEG(first)
     else:
         await v.playFFmpeg(sec)


### PR DESCRIPTION
Uses a bare `raise` statement inside the `except` blocks so that it reraises the exception instead of making a new one.
Has the benefits of
- Not creating more allocations for the same exception (Literally unnoticable in performance lol)
- Doesn't erase the type of the exception. Means user can better tell apart the errors
- Doesn't remove procs from the stack trace (See example below)

```nim
template reRaise() = 
  when defined(bareRaise):
    raise
  else:
    raise newException(Exception, getCurrentExceptionMsg())

proc foo() = 
  raise (ref ValueError)(msg: "Test")

proc bar() = 
  try:
    foo()
  except:
    reRaise()

proc main() =
  try:
    bar()
  except ValueError:
    reRaise()

main()
```

**Bare raise**
```
/tmp/test.nim(22)        test
/tmp/test.nim(17)        main
/tmp/test.nim(11)        bar
/tmp/test.nim(6)         foo
Error: unhandled exception: Test [ValueError]
```

**New exception**
```
/tmp/test.nim(22)        test
/tmp/test.nim(17)        main
/tmp/test.nim(13)        bar
Error: unhandled exception: Test [Exception]
```

See how the new exception loses the call to `foo` and also removes the `ValueError` type from the exception.

Sorry about the weird whitespace changes, my editor just does that