### PR TITLE
[WIP] fixes #112; alt design to #101 using inheritance instead of global vars

### DIFF
--- a/dimscord/dispatch.nim
+++ b/dimscord/dispatch.nim
@@ -435,12 +435,14 @@ proc channelCreate(s: Shard, data: JsonNode) {.async.} =
             guild = some s.cache.guilds[guild.get.id]
 
         chan = some newGuildChannel(data)
+        chan.unsafeGet.setContext(s.client.api)
 
         if s.cache.preferences.cache_guild_channels:
             s.cache.guildChannels[chan.get.id] = chan.get
             guild.get.channels[chan.get.id] = chan.get
     elif data["id"].str notin s.cache.dmChannels:
         dmChan = some newDMChannel(data)
+        dmChan.unsafeGet.setContext(s.client.api)
         if s.cache.preferences.cache_dm_channels:
             s.cache.dmChannels[data["id"].str] = dmChan.get
 
@@ -460,6 +462,9 @@ proc channelUpdate(s: Shard, data: JsonNode) {.async.} =
         guild.channels[gchan.id] = gchan
         s.cache.guildChannels[gchan.id] = gchan
 
+    gchan.setContext(s.client.api)
+    if oldChan.isSome:
+        oldChan.unsafeGet.setContext(s.client.api)
     asyncCheck s.client.events.channel_update(s, guild, gchan, oldChan)
 
 proc channelDelete(s: Shard, data: JsonNode) {.async.} =
@@ -475,6 +480,7 @@ proc channelDelete(s: Shard, data: JsonNode) {.async.} =
 
     if data["id"].str in s.cache.guildChannels:
         gc = some newGuildChannel(data)
+        gc.unsafeGet.setContext(s.client.api)
 
         if guild.get.id in s.cache.guilds:
             guild.get.channels.del(gc.get.id)
@@ -482,6 +488,8 @@ proc channelDelete(s: Shard, data: JsonNode) {.async.} =
         s.cache.guildChannels.del(gc.get.id)
     elif data["id"].str in s.cache.dmChannels:
         dm = some newDMChannel(data)
+        dm.unsafeGet.setContext(s.client.api)
+
         s.cache.dmChannels.del(dm.get.id)
 
     asyncCheck s.client.events.channel_delete(s, guild, gc, dm)

--- a/dimscord/dispatch.nim
+++ b/dimscord/dispatch.nim
@@ -155,7 +155,7 @@ proc presenceUpdate(s: Shard, data: JsonNode) {.async.} =
         asyncCheck s.client.events.presence_update(s, presence, oldPresence)
 
 proc messageCreate(s: Shard, data: JsonNode) {.async.} =
-    let msg = newMessage(data)
+    let msg = newMessage(data, s.client.api)
 
     if msg.channel_id in s.cache.guildChannels:
         let chan = s.cache.guildChannels[msg.channel_id]
@@ -314,6 +314,7 @@ proc messageReactionRemoveAll(s: Shard, data: JsonNode) {.async.} =
     if msg.reactions.len > 0:
         msg.reactions.clear()
 
+    if msg.ctx.isNil: msg.ctx = s.client.api
     asyncCheck s.client.events.message_reaction_remove_all(s, msg, exists)
 
 proc messageDelete(s: Shard, data: JsonNode) {.async.} =
@@ -380,6 +381,7 @@ proc messageUpdate(s: Shard, data: JsonNode) {.async.} =
         msg = msg.updateMessage(data)
         if msg.id in chan.messages: chan.messages[msg.id] = msg
 
+    if msg.ctx.isNil: msg.ctx = s.client.api
     asyncCheck s.client.events.message_update(s, msg, oldMessage, exists)
 
 proc messageDeleteBulk(s: Shard, data: JsonNode) {.async.} =

--- a/dimscord/dispatch.nim
+++ b/dimscord/dispatch.nim
@@ -155,7 +155,7 @@ proc presenceUpdate(s: Shard, data: JsonNode) {.async.} =
         asyncCheck s.client.events.presence_update(s, presence, oldPresence)
 
 proc messageCreate(s: Shard, data: JsonNode) {.async.} =
-    let msg = newMessage(data, s.client.api)
+    let msg = newMessage(data)
 
     if msg.channel_id in s.cache.guildChannels:
         let chan = s.cache.guildChannels[msg.channel_id]
@@ -314,7 +314,6 @@ proc messageReactionRemoveAll(s: Shard, data: JsonNode) {.async.} =
     if msg.reactions.len > 0:
         msg.reactions.clear()
 
-    if msg.ctx.isNil: msg.ctx = s.client.api
     asyncCheck s.client.events.message_reaction_remove_all(s, msg, exists)
 
 proc messageDelete(s: Shard, data: JsonNode) {.async.} =
@@ -381,7 +380,6 @@ proc messageUpdate(s: Shard, data: JsonNode) {.async.} =
         msg = msg.updateMessage(data)
         if msg.id in chan.messages: chan.messages[msg.id] = msg
 
-    if msg.ctx.isNil: msg.ctx = s.client.api
     asyncCheck s.client.events.message_update(s, msg, oldMessage, exists)
 
 proc messageDeleteBulk(s: Shard, data: JsonNode) {.async.} =

--- a/dimscord/dispatch.nim
+++ b/dimscord/dispatch.nim
@@ -169,6 +169,7 @@ proc messageCreate(s: Shard, data: JsonNode) {.async.} =
         asyncCheck chan.addMsg(msg, $data, s.cache.preferences)
         chan.last_message_id = msg.id
 
+    msg.setContext(s.client.api)
     asyncCheck s.client.events.message_create(s, msg)
 
 proc messageReactionAdd(s: Shard, data: JsonNode) {.async.} =
@@ -214,6 +215,7 @@ proc messageReactionAdd(s: Shard, data: JsonNode) {.async.} =
         reaction.reacted = data["user_id"].str == s.user.id
         msg.reactions[$emoji] = reaction
 
+    msg.setContext(s.client.api)
     asyncCheck s.client.events.message_reaction_add(s, msg, user, emoji, exists)
 
 proc messageReactionRemove(s: Shard, data: JsonNode) {.async.} =
@@ -257,6 +259,7 @@ proc messageReactionRemove(s: Shard, data: JsonNode) {.async.} =
     else:
         msg.reactions.del($emoji)
 
+    msg.setContext(s.client.api)
     asyncCheck s.client.events.message_reaction_remove(s, msg, user,
         reaction, exists)
 
@@ -286,6 +289,7 @@ proc messageReactionRemoveEmoji(s: Shard, data: JsonNode) {.async.} =
 
     msg.reactions.del($emoji)
 
+    msg.setContext(s.client.api)
     asyncCheck s.client.events.message_reaction_remove_emoji(s, msg, emoji, exists)
 
 proc messageReactionRemoveAll(s: Shard, data: JsonNode) {.async.} =
@@ -314,6 +318,7 @@ proc messageReactionRemoveAll(s: Shard, data: JsonNode) {.async.} =
     if msg.reactions.len > 0:
         msg.reactions.clear()
 
+    msg.setContext(s.client.api)
     asyncCheck s.client.events.message_reaction_remove_all(s, msg, exists)
 
 proc messageDelete(s: Shard, data: JsonNode) {.async.} =
@@ -349,6 +354,7 @@ proc messageDelete(s: Shard, data: JsonNode) {.async.} =
 
         chan.messages.del(msg.id)
 
+    msg.setContext(s.client.api)
     asyncCheck s.client.events.message_delete(s, msg, exists)
 
 proc messageUpdate(s: Shard, data: JsonNode) {.async.} =
@@ -380,6 +386,9 @@ proc messageUpdate(s: Shard, data: JsonNode) {.async.} =
         msg = msg.updateMessage(data)
         if msg.id in chan.messages: chan.messages[msg.id] = msg
 
+    msg.setContext(s.client.api)
+    if oldMessage.isSome:
+        oldMessage.unsafeGet.setContext(s.client.api)
     asyncCheck s.client.events.message_update(s, msg, oldMessage, exists)
 
 proc messageDeleteBulk(s: Shard, data: JsonNode) {.async.} =
@@ -408,6 +417,7 @@ proc messageDeleteBulk(s: Shard, data: JsonNode) {.async.} =
                 chan.messages.del(m.id)
                 exists = true
 
+        m.setContext(s.client.api)
         mids.add (msg: m, exists: exists)
 
     asyncCheck s.client.events.message_delete_bulk(s, mids)

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -588,8 +588,11 @@ proc updateMessage*(m: Message, data: JsonNode): Message =
         mention_users = data{"mentions"}.getElems.map(newUser)
         attachments = data{"attachments"}.getElems.map(newAttachment)
         embeds = data{"embeds"}.getElems.mapIt(it.`$`.fromJson(Embed))
+        
     if result.referenced_message.isSome and "referenced_message" in data:
         result.referenced_message = some data["referenced_message"].newMessage
+        result.referenced_message.get.setContext(m.ctx)
+
     if result.messageReference.isSome:
         if "message_reference"in data and data["message_reference"].kind!=JNull:
             result.message_reference = some ($data{"message_reference"}).fromJson(

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -323,9 +323,8 @@ proc renameHook(s: var MessageInteraction, fieldName: var string) =
     if fieldName == "type":
         fieldName = "kind"
 
-proc newMessage*(data: JsonNode, api: RestApi): Message =
+proc newMessage*(data: JsonNode): Message =
     result = data.`$`.fromJson(Message)
-    result.ctx = api
 
 proc newGuildChannel*(data: JsonNode): GuildChannel =
     result = ($data).fromJson(GuildChannel)
@@ -590,7 +589,7 @@ proc updateMessage*(m: Message, data: JsonNode): Message =
         attachments = data{"attachments"}.getElems.map(newAttachment)
         embeds = data{"embeds"}.getElems.mapIt(it.`$`.fromJson(Embed))
     if result.referenced_message.isSome and "referenced_message" in data:
-        result.referenced_message = some data["referenced_message"].newMessage(nil)
+        result.referenced_message = some data["referenced_message"].newMessage
     if result.messageReference.isSome:
         if "message_reference"in data and data["message_reference"].kind!=JNull:
             result.message_reference = some ($data{"message_reference"}).fromJson(

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -323,8 +323,9 @@ proc renameHook(s: var MessageInteraction, fieldName: var string) =
     if fieldName == "type":
         fieldName = "kind"
 
-proc newMessage*(data: JsonNode): Message =
+proc newMessage*(data: JsonNode, api: RestApi): Message =
     result = data.`$`.fromJson(Message)
+    result.ctx = api
 
 proc newGuildChannel*(data: JsonNode): GuildChannel =
     result = ($data).fromJson(GuildChannel)
@@ -589,7 +590,7 @@ proc updateMessage*(m: Message, data: JsonNode): Message =
         attachments = data{"attachments"}.getElems.map(newAttachment)
         embeds = data{"embeds"}.getElems.mapIt(it.`$`.fromJson(Embed))
     if result.referenced_message.isSome and "referenced_message" in data:
-        result.referenced_message = some data["referenced_message"].newMessage
+        result.referenced_message = some data["referenced_message"].newMessage(nil)
     if result.messageReference.isSome:
         if "message_reference"in data and data["message_reference"].kind!=JNull:
             result.message_reference = some ($data{"message_reference"}).fromJson(

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -248,7 +248,7 @@ type
         resume_gateway_url*, session_id*: string
         shard*: Option[seq[int]]
         application*: tuple[id: string, flags: set[ApplicationFlags]]
-    DMChannel* = ref object
+    DMChannel* = ref object of DimscordObject
         id*, last_message_id*: string
         kind*: ChannelType
         recipients*: seq[User]
@@ -259,7 +259,7 @@ type
         id*, name*: string
         moderated: bool
         emoji_id*, emoji_name*: Option[string]
-    GuildChannel* = ref object
+    GuildChannel* = ref object of DimscordObject
         id*, name*, guild_id*: string
         nsfw*: bool
         parent_id*: Option[string]
@@ -901,7 +901,7 @@ proc `$`*(e: Emoji): string =
         else:
             e.name.get("?")
 
-proc setContext*[T: DimscordObject](obj: var T | lent T, api: RestApi) {.inline.} =
+proc setContext*[T: DimscordObject](obj: var T | T, api: RestApi) {.inline.} =
     ## Sets the `ctx` field of a single of `DimscordObject`
     if not (api.isNil):
         obj.ctx = api

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -7,6 +7,8 @@ import std/asyncnet
 
 type
     RestError* = object of CatchableError
+    DimscordObject* = ref object of RootObj
+        ctx* : RestApi
     DiscordFile* = ref object
         ## A Discord file.
         name*, body*: string
@@ -136,7 +138,7 @@ type
         channel_id*: Option[string]
         message_id*, guild_id*: Option[string]
         fail_if_not_exists*: Option[bool]
-    Message* = ref object
+    Message* = ref object of DimscordObject
         ## - `sticker_items` == Table[sticker_id, object]
         ## - `reactions` == Table["REACTION_EMOJI", object]
         id*, channel_id*: string
@@ -898,3 +900,4 @@ proc `$`*(e: Emoji): string =
             e.name.get("?") & ":" & e.id.get
         else:
             e.name.get("?")
+

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -7,8 +7,6 @@ import std/asyncnet
 
 type
     RestError* = object of CatchableError
-    DimscordObject* = ref object of RootObj
-        ctx* : RestApi
     DiscordFile* = ref object
         ## A Discord file.
         name*, body*: string
@@ -138,7 +136,7 @@ type
         channel_id*: Option[string]
         message_id*, guild_id*: Option[string]
         fail_if_not_exists*: Option[bool]
-    Message* = ref object of DimscordObject
+    Message* = ref object
         ## - `sticker_items` == Table[sticker_id, object]
         ## - `reactions` == Table["REACTION_EMOJI", object]
         id*, channel_id*: string
@@ -900,4 +898,3 @@ proc `$`*(e: Emoji): string =
             e.name.get("?") & ":" & e.id.get
         else:
             e.name.get("?")
-

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -7,6 +7,8 @@ import std/asyncnet
 
 type
     RestError* = object of CatchableError
+    DimscordObject* = ref object of RootObj
+        ctx*: RestApi
     DiscordFile* = ref object
         ## A Discord file.
         name*, body*: string
@@ -136,7 +138,7 @@ type
         channel_id*: Option[string]
         message_id*, guild_id*: Option[string]
         fail_if_not_exists*: Option[bool]
-    Message* = ref object
+    Message* = ref object of DimscordObject
         ## - `sticker_items` == Table[sticker_id, object]
         ## - `reactions` == Table["REACTION_EMOJI", object]
         id*, channel_id*: string
@@ -898,3 +900,14 @@ proc `$`*(e: Emoji): string =
             e.name.get("?") & ":" & e.id.get
         else:
             e.name.get("?")
+
+proc setContext*[T: DimscordObject](obj: var T | lent T, api: RestApi) {.inline.} =
+    ## Sets the `ctx` field of a single of `DimscordObject`
+    if not (api.isNil):
+        obj.ctx = api
+
+proc setContext*[T: DimscordObject](obj: var seq[T], api: RestApi) {.inline.} =
+    ## Sets the `ctx` field for every item in `seq[DimscordObject]`
+    if not (api.isNil):
+        for item in obj:
+            item.ctx = api

--- a/dimscord/restapi/channel.nim
+++ b/dimscord/restapi/channel.nim
@@ -1,6 +1,6 @@
 import asyncdispatch, json, options, jsony
 import ../objects, ../constants, ../helpers
-import tables, sequtils, sugar
+import tables, sequtils
 import uri, macros, requester
 
 proc triggerTypingIndicator*(api: RestApi, channel_id: string) {.async.} =
@@ -28,9 +28,10 @@ proc deleteChannelMessagePin*(api: RestApi,
 proc getChannelPins*(api: RestApi,
         channel_id: string): Future[seq[Message]] {.async.} =
     ## Get channel pins.
-    result = collect:
-        for node in (await api.request("GET",endpointChannelPins(channel_id))).elems:
-            newMessage(node, api)
+    result = (await api.request(
+        "GET",
+        endpointChannelPins(channel_id)
+    )).elems.map(newMessage)
 
 proc editGuildChannel*(api: RestApi, channel_id: string;
             name, parent_id, topic = none string;

--- a/dimscord/restapi/channel.nim
+++ b/dimscord/restapi/channel.nim
@@ -32,6 +32,7 @@ proc getChannelPins*(api: RestApi,
         "GET",
         endpointChannelPins(channel_id)
     )).elems.map(newMessage)
+    result.setContext(api)
 
 proc editGuildChannel*(api: RestApi, channel_id: string;
             name, parent_id, topic = none string;
@@ -60,6 +61,7 @@ proc editGuildChannel*(api: RestApi, channel_id: string;
         $payload,
         audit_reason = reason
     )).newGuildChannel
+    result.setContext(api)
 
 proc createGuildChannel*(api: RestApi, guild_id, name: string; kind = 0;
             parent_id, topic = none string; nsfw = none bool;
@@ -82,6 +84,8 @@ proc createGuildChannel*(api: RestApi, guild_id, name: string; kind = 0;
         $payload,
         audit_reason = reason
     )).newGuildChannel
+    result.setContext(api)
+
 
 proc deleteChannel*(api: RestApi, channel_id: string; reason = "") {.async.} =
     ## Deletes or closes a channel.
@@ -186,8 +190,12 @@ proc getChannel*(api: RestApi;
     ))
     if data["type"].getInt == int ctDirect:
         result = (none GuildChannel, some newDMChannel(data))
+        result[1].unsafeGet.setContext(api)
+
     else:
         result = (some newGuildChannel(data), none DMChannel)
+        result[0].unsafeGet.setContext(api)
+
 
 proc getGuildChannels*(api: RestApi,
         guild_id: string): Future[seq[GuildChannel]] {.async.} =
@@ -196,6 +204,8 @@ proc getGuildChannels*(api: RestApi,
         "GET",
         endpointGuildChannels(guild_id)
     )).elems.map(newGuildChannel)
+    result.setContext(api)
+
 
 proc editGuildChannelPositions*(api: RestApi, guild_id, channel_id: string;
         position = none int; parent_id = none string; lock_permissions = false;
@@ -292,6 +302,8 @@ proc startThreadWithoutMessage*(api: RestApi,
         $payload,
         audit_reason = reason
     )).newGuildChannel
+    result.setContext(api)
+
 
 proc listArchivedThreads*(api: RestApi;
     joined: bool; typ, channel_id: string;
@@ -322,6 +334,8 @@ proc listArchivedThreads*(api: RestApi;
         members: seq[ThreadMember],
         has_more: bool
     ])
+    result[0].setContext(api)
+
 
 proc createStageInstance*(api: RestApi; channel_id, topic: string;
     privacy_level = int plGuildOnly; reason = ""

--- a/dimscord/restapi/channel.nim
+++ b/dimscord/restapi/channel.nim
@@ -1,6 +1,6 @@
 import asyncdispatch, json, options, jsony
 import ../objects, ../constants, ../helpers
-import tables, sequtils
+import tables, sequtils, sugar
 import uri, macros, requester
 
 proc triggerTypingIndicator*(api: RestApi, channel_id: string) {.async.} =
@@ -28,10 +28,9 @@ proc deleteChannelMessagePin*(api: RestApi,
 proc getChannelPins*(api: RestApi,
         channel_id: string): Future[seq[Message]] {.async.} =
     ## Get channel pins.
-    result = (await api.request(
-        "GET",
-        endpointChannelPins(channel_id)
-    )).elems.map(newMessage)
+    result = collect:
+        for node in (await api.request("GET",endpointChannelPins(channel_id))).elems:
+            newMessage(node, api)
 
 proc editGuildChannel*(api: RestApi, channel_id: string;
             name, parent_id, topic = none string;

--- a/dimscord/restapi/guild.nim
+++ b/dimscord/restapi/guild.nim
@@ -752,6 +752,8 @@ proc listActiveGuildThreads*(
         threads: data["threads"].elems.map(newGuildChannel),
         members: data["members"].elems.mapIt(($it).fromJson(ThreadMember))
     )
+    result[0].setContext(api)
+
 
 proc getScheduledEvent*(api: RestApi;
         guild_id, event_id: string;

--- a/dimscord/restapi/message.nim
+++ b/dimscord/restapi/message.nim
@@ -668,3 +668,4 @@ proc startThreadWithMessage*(api: RestApi,
         }),
         audit_reason = reason
     )).newGuildChannel
+    result.setContext(api)

--- a/dimscord/restapi/user.nim
+++ b/dimscord/restapi/user.nim
@@ -93,6 +93,7 @@ proc createUserDm*(api: RestApi, user_id: string): Future[DMChannel]{.async.} =
     result = (await api.request("POST", endpointUserChannels(), $(%*{
         "recipient_id": user_id
     }))).newDMChannel
+    result.setContext(api)
 
 proc getCurrentUser*(api: RestApi): Future[User] {.async.} =
     ## Gets the current user.
@@ -129,6 +130,7 @@ proc createGroupDm*(api: RestApi,
             "nicks": %nicks
         })
     )).newDMChannel
+    result.setContext(api)
 
 proc getCurrentApplication*(api: RestApi): Future[Application] {.async.} =
     ## Gets the current application for the current user (bot user).


### PR DESCRIPTION
fixes https://github.com/krisppurg/dimscord/issues/112; alternative to https://github.com/krisppurg/dimscord/pull/101 using inheritance to allow referencing the current state of the user's `RestApi` from inside the library; is also likely to integrate well with the current design of https://github.com/krisppurg/dimscord/pull/110

important info/considerations:
- the implementation relies on objects from the cache table to reliably populate the `ctx` field, it will be `nil` if it didn't !
- consider relying on compile time mechanisms to ensure any `DimscordObject` object that return from procedures do not have a `nil` field.
- it must be decided whether to make `DimscordObject.ctx` a public or private field for safety reasons

tasks:
- [ ] port helping procs from https://github.com/krisppurg/dimscord/pull/101 to this pr
- [ ] ensure that `DimscordObject.ctx` is properly populated for every objects