### PR TITLE
`MessageComponent` helpers now accept `openArray`/`varargs` where appropriate 

### DIFF
--- a/dimscord/helpers.nim
+++ b/dimscord/helpers.nim
@@ -10,7 +10,7 @@ import macros
 
 macro event*(discord: DiscordClient, fn: untyped): untyped =
     ## Sugar for registering an event handler.
-    let 
+    let
         eventName = fn[0]
         params = fn[3]
         pragmas = fn[4]
@@ -200,7 +200,7 @@ proc computePerms*(guild: Guild;
         member: Member, channel: GuildChannel): PermObj =
     ## Returns the permissions for the guild member of the channel.
     ## For permission checking you can do something like this:
-    ## 
+    ##
     ## .. code-block:: Nim
     ##    cast[int](setofpermshere).permCheck(PermObj(
     ##        allowed: {permExample}
@@ -237,10 +237,10 @@ proc computePerms*(guild: Guild;
 proc createBotInvite*(client_id: string, permissions: set[PermissionFlags]={};
         guild_id = ""; disable_guild_select = false): string =
     ## Creates an invite link for the bot of the form.
-    ## 
+    ##
     ## Example:
     ## `https://discord.com/api/oauth2/authorize?client_id=1234&scope=bot&permissions=1`
-    ## 
+    ##
     ## See https://discord.com/developers/docs/topics/oauth2#bots for more information.
     result = restBase & "oauth2/authorize?client_id=" & client_id &
         "&scope=bot&permissions=" & $cast[int](permissions)
@@ -315,13 +315,13 @@ proc checkActionRow*(row: MessageComponent) =
     else:
         assert not contains.hasKey(ActionRow), "Action row cannot contain an action row"
 
-proc newActionRow*(components: seq[MessageComponent] = @[]): MessageComponent =
+proc newActionRow*(components: varargs[MessageComponent]): MessageComponent =
     ## Creates a new action row which you can add components to.
     ## It is recommended to use this over raw objects since this
     ## does validation of the row as you add objects
     result = MessageComponent(
         kind: ActionRow,
-        components: components
+        components: @components
     )
     if components.len > 0:
         checkActionRow result

--- a/dimscord/helpers.nim
+++ b/dimscord/helpers.nim
@@ -371,7 +371,7 @@ proc newMenuOption*(label: string, value: string,
         default: some default
     )
 
-proc newSelectMenu*(custom_id: string; options: seq[SelectmenuOption];
+proc newSelectMenu*(custom_id: string; options: openArray[SelectmenuOption];
         placeholder = ""; minValues, maxValues = 1;
         disabled = false
 ): MessageComponent =
@@ -391,7 +391,7 @@ proc newSelectMenu*(custom_id: string; options: seq[SelectmenuOption];
     result = MessageComponent(
         kind: SelectMenu,
         customID: some customID,
-        options: options,
+        options: @options,
         placeholder: optionIf(placeholder == ""),
         minValues: some minValues,
         maxValues: some maxValues

--- a/examples/message_components.nim
+++ b/examples/message_components.nim
@@ -31,7 +31,7 @@ proc messageCreate(s: Shard, m: Message) {.event(discord).} =
                 emoji = Emoji(name: some "🔥")
             )
         of "menu":
-            row &= newSelectMenu("slmColours", @[
+            row &= newSelectMenu("slmColours", [
                 newMenuOption("Red", "red", emoji = Emoji(name: some "🔥")),
                 newMenuOption("Green", "green"),
                 newMenuOption("Blue", "blue")


### PR DESCRIPTION
Noticed while looking at #115 that `newActionRow` required a seq when it wasn't really required. It now takes `varargs` instead so that it can now be called like
```nim
  let
    # Existing uses still work
    a = newActionRow(@[MessageComponent()])
    # Can just pass an array
    b = newActionRow([MessageComponent()])
    # Can just pass a series of components
    c = newActionRow(MessageComponent(), MessageComponent())
```