### PR TITLE
new `Context` type to allow shortening code

### DIFF
--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -15,6 +15,7 @@ type
         ## For parse: The values should be "roles", "users", "everyone"
         parse*, roles*, users*: seq[string]
         replied_user*: bool
+    Context* = DiscordClient | Shard | RestApi
     DiscordClient* = ref object
         api*: RestApi
         events*: Events
@@ -899,3 +900,10 @@ proc `$`*(e: Emoji): string =
             e.name.get("?") & ":" & e.id.get
         else:
             e.name.get("?")
+
+
+template api*[T: Context](ctx: T): RestApi =
+    result = 
+        when ctx is Shard: ctx.client.api
+        elif ctx is DiscordClient: ctx.api
+        elif ctx is RestApi: ctx

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -903,7 +903,6 @@ proc `$`*(e: Emoji): string =
 
 
 template api*[T: Context](ctx: T): RestApi =
-    result = 
-        when ctx is Shard: ctx.client.api
-        elif ctx is DiscordClient: ctx.api
-        elif ctx is RestApi: ctx
+    when ctx is Shard: ctx.client.api
+    elif ctx is DiscordClient: ctx.api
+    elif ctx is RestApi: ctx


### PR DESCRIPTION
This PR improves the library's API by allowing users to directly pass `Shard` or `DiscordClient` to procs that interact with Discord's Rest API. `RestApi` is part of `Context` in order to maintain compatibility with old code.

Before:
```nim
let discord = newDiscordClient("token")

var cmd = discord.newHandler() 

cmd.addSlash("ping", guildID = "0000000000000000000") do (s: Shard, i: Interaction):
    ## Ping the bot 
    let
        ch = s.cache.guildChannels[i.channel_id.get]

        before = epochTime() * 1000
        msg = await discord.api.sendMessage(ch.id, "Success!")
        after = epochTime() * 1000

    discard await discord.api.editMessage(ch.id, msg.id, "Pong! took " & $int(after - before) & "ms | " & $s.latency() & "ms.")
 ```
 After:
 ```nim
 let discord = newDiscordClient("token")

var cmd = discord.newHandler() 

cmd.addSlash("ping", guildID = "0000000000000000000") do (s: Shard, i: Interaction):
    ## Ping the bot 
    let
        ch = s.cache.guildChannels[i.channel_id.get]

        before = epochTime() * 1000
        msg = await s.sendMessage(ch.id, "Success!")
        after = epochTime() * 1000

    discard await discord.editMessage(ch.id, msg.id, "Pong! took " & $int(after - before) & "ms | " & $s.latency() & "ms.")
```
Notice how I can pass `discord` or `s` variables directly. Users can call the `discord` variable anything they want so it could be `ctx` to match the name of the type in question (could also be demonstrated in documentation).

Note: This is a two-part PR, a followup PR is to be expected that would make use of this feature across the library.