### PR TITLE
Update the range for command names

### DIFF
--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -872,7 +872,7 @@ proc `%%*`*(a: ApplicationCommandOption): JsonNode =
         )
 
 proc `%%*`*(a: ApplicationCommand): JsonNode =
-    assert a.name.len in 3..32
+    assert a.name.len in 1..32
     # This ternary is needed so that the enums can stay similar to
     # the discord api
     let commandKind = if a.kind == atNothing: atSlash else: a.kind


### PR DESCRIPTION
Application command names can now be in the range `1..32`

[See docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure)