### PR TITLE
Cleanup `event` pragma

### DIFF
--- a/dimscord/helpers.nim
+++ b/dimscord/helpers.nim
@@ -65,19 +65,17 @@ macro event*(discord: DiscordClient, fn: untyped): untyped =
         newEmptyNode(),
         body
     )
-    anonFn.copyLineInfo(fn)
 
     if pragmas.findChild(it.strVal == "async").kind == nnkNilLit:
         anonFn.addPragma ident("async")
     # Check the event is valid, give proper error if it isn't
     if eventName.strVal.nimIdentNormalize() notin dimscordEvents:
-        fmt"{eventName} is not a valid dimscord event".error(eventName)
-    # Manually create the assignment so the line info is kept
-    # discord.events.`eventName` = anonFn
-    result = nnkAsgn.newTree(
-        discord.newDotExpr(ident"events").newDotExpr(ident $eventName),
-        anonFn
-    )
+        fmt"'{eventName}' is not a valid dimscord event".error(eventName)
+
+    result = quote:
+        `discord`.events.`eventName` = `anonFn`
+    # Make sure the `anonFn` keeps its line info
+    result[1].copyLineInfo(fn)
 
 proc defaultAvatarUrl*(u: User): string =
     ## Returns the default avatar for a user.

--- a/dimscord/helpers.nim
+++ b/dimscord/helpers.nim
@@ -65,12 +65,19 @@ macro event*(discord: DiscordClient, fn: untyped): untyped =
         newEmptyNode(),
         body
     )
+    anonFn.copyLineInfo(fn)
 
     if pragmas.findChild(it.strVal == "async").kind == nnkNilLit:
         anonFn.addPragma ident("async")
-
-    quote:
-        `discord`.events.`eventName` = `anonFn`
+    # Check the event is valid, give proper error if it isn't
+    if eventName.strVal.nimIdentNormalize() notin dimscordEvents:
+        fmt"{eventName} is not a valid dimscord event".error(eventName)
+    # Manually create the assignment so the line info is kept
+    # discord.events.`eventName` = anonFn
+    result = nnkAsgn.newTree(
+        discord.newDotExpr(ident"events").newDotExpr(ident $eventName),
+        anonFn
+    )
 
 proc defaultAvatarUrl*(u: User): string =
     ## Returns the default avatar for a user.
@@ -497,37 +504,6 @@ proc add*(component: var MessageComponent, item: SelectMenuOption) =
     component.options &= item
 
 # Event Handlers
-
-const procsTable = macrocache.CacheTable"dimscord.handlerTypes"
-    ## Stores a mapping of EventName -> parameters for event
-    ## Note:: The shared parameter is removed from them
-
-# Build up the procsTable
-static:
-    # getTypleImpl returns `ref ObjSym` so we need to get the impl of ObjSym
-    let impl = Events.getTypeImpl()[0].getImpl()
-    for identDefs in impl[2][2]:
-        var typ = identDefs[^2]
-
-        # Desym all the parameters
-        var params = newSeq[NimNode]()
-        # Skip return type and shard parameter
-        for identDef in typ[0][2 .. ^1]:
-            var newDef = nnkIdentDefs.newTree()
-            for param in identDef[0 ..< ^2]:
-                newDef &= ident $param
-            newDef &= identDef[^2]
-            newDef &= identDef[^1]
-            params &= newDef
-
-        for field in identDefs[0 ..< ^2]:
-            # Not exported so just ignore it
-            if field.kind == nnkIdent: continue
-            # Remove the on_ prefix for some events
-            let origName = $field[1]
-            let name = if origName == "on_dispatch": "unknown"
-                       else: dup(origName, removePrefix("on_"))
-            procsTable[name] = newStmtList(params).copy()
 
 proc params(event: DispatchEvent): NimNode =
     ## Returns the proc type stored for an event

--- a/dimscord/helpers.nim
+++ b/dimscord/helpers.nim
@@ -11,6 +11,41 @@ import typetraits, json
 import std/[macros, macrocache]
 include ./helpers/[channel, guild, message, user]
 
+const
+    procsTable = macrocache.CacheTable"dimscord.handlerTypes"
+        ## Stores a mapping of EventName -> parameters for event
+        ## Note:: The shared parameter is removed from them
+    dimscordEvents = macrocache.CacheTable"dimscord.eventNames"
+        ## Stores names of events that exist. Basically
+        ## a HashSet
+
+# Build up the procsTable
+static:
+    # getTypleImpl returns `ref ObjSym` so we need to get the impl of ObjSym
+    let impl = Events.getTypeImpl()[0].getImpl()
+    for identDefs in impl[2][2]:
+        var typ = identDefs[^2]
+
+        # Desym all the parameters
+        var params = newSeq[NimNode]()
+        # Skip return type and shard parameter
+        for identDef in typ[0][2 .. ^1]:
+            var newDef = nnkIdentDefs.newTree()
+            for param in identDef[0 ..< ^2]:
+                newDef &= ident $param
+            newDef &= identDef[^2]
+            newDef &= identDef[^1]
+            params &= newDef
+
+        for field in identDefs[0 ..< ^2]:
+            # Not exported so just ignore it
+            if field.kind == nnkIdent: continue
+            # Remove the on_ prefix for some events
+            let origName = $field[1]
+            let name = if origName == "on_dispatch": "unknown"
+                       else: dup(origName, removePrefix("on_"))
+            procsTable[name] = newStmtList(params).copy()
+            dimscordEvents[origName.nimIdentNormalize()] = newEmptyNode()
 
 macro event*(discord: DiscordClient, fn: untyped): untyped =
     ## Sugar for registering an event handler.


### PR DESCRIPTION
#### Error message

Updates the error message when the event is wrong. It now errors on the proc name instead of giving an undeclared field error
**Before**
```
/tmp/test.nim(9, 35) template/generic instantiation of `event` from here
/home/user/.nimble/pkgs2/dimscord/dimscord/helpers.nim(37, 5) Error: undeclared field: 'test=' for type objects.Events [type declared in /home/user/.nimble/pkgs2/dimscord/dimscord/objects/typedefs.nim(849, 5)]
```
**After**
```
/home/user/Documents/projects/dimscord/dimscord/helpers.nim(74, 57) event
/home/user/Documents/projects/dimscord/test.nim(9, 6) Error: 'test' is not a valid dimscord event
```

#### Line info
Also makes sure the anonymous function has the same line info as the function, helps make some warnings/errors point to the right line
