### PR TITLE
Add state key to ActivityStatus for custom activities

### DIFF
--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -266,9 +266,9 @@ proc updateStatus*(s: Shard, activities: seq[ActivityStatus] = @[];
     for activity in activities:
       case activity.kind
       of atCustom:
-        payload["activities"]["state"] = activity.state
+        payload["activities"]["state"] = &activity.state
       else:
-        payload["activities"]["name"] = activity.state
+        payload["activities"]["name"] = &activity.name
 
     await s.sendSock(opStatusUpdate, payload)
 

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -260,13 +260,15 @@ proc updateStatus*(s: Shard, activities: seq[ActivityStatus] = @[];
     payload["activities"] = &activities.mapIt(%%{
         "type": &uint8 it.kind,
         "name": &it.name,
-        "url": &it.url,
-        case it.kind
-        of atCustom:
-          "state": &it.state
-        else:
-          "name": &it.name
+        "url": &it.url
     })
+
+    case it.kind
+    of atCustom:
+      payload["activities"]["state"] = &it.state
+    else:
+      payload["activities"]["name"] = &it.name
+
     await s.sendSock(opStatusUpdate, payload)
 
 proc updateStatus*(s: Shard, activity = none ActivityStatus;

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -260,7 +260,12 @@ proc updateStatus*(s: Shard, activities: seq[ActivityStatus] = @[];
     payload["activities"] = &activities.mapIt(%%{
         "type": &uint8 it.kind,
         "name": &it.name,
-        "url": &it.url
+        "url": &it.url,
+        case it.kind
+        of atCustom:
+          "state": &it.state
+        else:
+          "name": &it.name
     })
     await s.sendSock(opStatusUpdate, payload)
 

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -260,16 +260,11 @@ proc updateStatus*(s: Shard, activities: seq[ActivityStatus] = @[];
     payload["activities"] = &activities.mapIt(%%{
         "type": &uint8 it.kind,
         "name": &it.name,
-        "url": &it.url
+        "url": &it.url,
+        "state": &it.state,
+        "name": &it.name
     })
     
-    for activity in activities:
-      case activity.kind
-      of atCustom:
-        payload["activities"]["state"] = &activity.state
-      else:
-        payload["activities"]["name"] = &activity.name
-
     await s.sendSock(opStatusUpdate, payload)
 
 proc updateStatus*(s: Shard, activity = none ActivityStatus;

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -262,12 +262,13 @@ proc updateStatus*(s: Shard, activities: seq[ActivityStatus] = @[];
         "name": &it.name,
         "url": &it.url
     })
-
-    case it.kind
-    of atCustom:
-      payload["activities"]["state"] = &it.state
-    else:
-      payload["activities"]["name"] = &it.name
+    
+    for activity in activities:
+      case activity.kind
+      of atCustom:
+        payload["activities"]["state"] = activity.state
+      else:
+        payload["activities"]["name"] = activity.state
 
     await s.sendSock(opStatusUpdate, payload)
 

--- a/dimscord/gateway.nim
+++ b/dimscord/gateway.nim
@@ -261,8 +261,7 @@ proc updateStatus*(s: Shard, activities: seq[ActivityStatus] = @[];
         "type": &uint8 it.kind,
         "name": &it.name,
         "url": &it.url,
-        "state": &it.state,
-        "name": &it.name
+        "state": &it.state
     })
     
     await s.sendSock(opStatusUpdate, payload)

--- a/dimscord/objects/typedefs.nim
+++ b/dimscord/objects/typedefs.nim
@@ -491,6 +491,7 @@ type
         name*: string
         kind*: ActivityType
         url*: Option[string]
+        state*: Option[string]  ## Only required when a custom activity type is set.
     Overwrite* = object
         ## - `kind` will be either ("role" or "member") or ("0" or "1")
         id*: string


### PR DESCRIPTION
This PR adds a `state` to `ActivityStatus`. This is necessary for custom activities, as specified by the Discord documentation.

This is how it is meant to be used (inside the `onReady` event)

```nim
await shard.updateStatus(
    activity = some ActivityStatus(
        name: "Custom Status", 
        state: some "Woohoo!", 
        kind: atCustom
    ), 
    status = "idle"
)
```

The `name` must always be "Custom Status", otherwise `state` will be ignored!

