### PR TITLE
Helpers fix 

### DIFF
--- a/dimscord/helpers/channel.nim
+++ b/dimscord/helpers/channel.nim
@@ -5,7 +5,7 @@ template pin*(m: Message, reason = ""): Future[void] =
     ## Add pinned message.
     getClient.api.addChannelMessagePin(m.channel_id, m.id, reason)
         
-template removePin*(m: Message, reason = ""): Future[void]  =
+template unpin*(m: Message, reason = ""): Future[void]  =
     ## Remove pinned message.
     getClient.api.deleteChannelMessagePin(m.channel_id, m.id, reason)
 
@@ -13,7 +13,7 @@ template getPins*(ch: SomeChannel): Future[seq[Message]] =
     ## Get channel pins.
     getClient.api.getChannelPins(ch.id)
 
-template editChannel*(ch: GuildChannel;
+template edit*(ch: GuildChannel;
     name, parent_id, topic, rtc_region = none string;
     default_auto_archive_duration, video_quality_mode = none int;
     flags = none set[ChannelFlags];
@@ -41,6 +41,7 @@ template createChannel*(g: Guild;
     parent_id, topic, rtc_region = none string; nsfw = none bool;
     position, video_quality_mode = none int;
     default_sort_order, default_forum_layout = none int;
+    default_thread_rate_limit_per_user = none int;
     available_tags = none seq[ForumTag];
     default_reaction_emoji = none DefaultForumReaction;
     rate_limit_per_user = none range[0..21600];
@@ -58,7 +59,7 @@ template createChannel*(g: Guild;
         permission_overwrites, reason
     )
 
-template deleteChannel*(ch: SomeChannel, reason = ""): Future[void] =
+template delete*(ch: SomeChannel, reason = ""): Future[void] =
     ## Deletes or closes a channel
     getClient.api.deleteChannel(ch.id, reason)
 
@@ -90,19 +91,19 @@ template getWebhooks*(ch: GuildChannel): Future[seq[Webhook]] =
     ## Gets a list of a channel's webhooks.
     getClient.api.getChannelWebhooks(ch.id)
 
-template deleteWebhook*(w: Webhook | string, reason = ""): Future[void] =
+template delete*(w: Webhook | string, reason = ""): Future[void] =
     ## Deletes a webhook.
     let wid = when w is Webhook: w.id else: w
     getClient.api.deleteWebhook(wid, reason)
 
-template editWebhook*(w: Webhook,
+template edit*(w: Webhook,
         name, avatar = none string;
         reason = ""): Future[void] =
     let chan = w.channel_id
     if chan.isSome:
         getClient.api.editWebhook(w.id, name, avatar, w.channel_id, reason)
     else:
-        raise newException(CatchableError, "Webhook is not in a channel") # TODO: i think editWebhook can work with none(channel_id) ?
+        raise newException(CatchableError, "Webhook is not in a channel") # TODO: i think editWebhook can work with none(channel_id)? no.
 
 template newThread*(ch: GuildChannel;
     name: string;
@@ -122,15 +123,13 @@ template createStageInstance*(ch: GuildChannel;
     ## Create a stage instance.
     getClient.api.createStageInstance(ch.id, topic, privacy, reason)
 
-template editStageInstance*(si: StageInstance | string,
+template editStageInstance*(si: StageInstance,
         topic = none string;
         privacy = none int; reason = ""): Future[StageInstance] =
     ## Modify a stage instance.
-    let st = when si is StageInstance: si.channel_id else: si
-    getClient.api.editStageInstance(st, topic, privacy, reason)
+    getClient.api.editStageInstance(si.channel_id, topic, privacy, reason)
 
-template deleteStageInstance*(si: StageInstance | string,
+template deleteStageInstance*(si: StageInstance,
         reason = ""): Future[void] =
     ## Delete the stage instance.
-    let st = when si is StageInstance: si.channel_id else: si
-    getClient.api.deleteStageInstance(st, reason)
+    getClient.api.deleteStageInstance(si.channel_id, reason)

--- a/dimscord/helpers/channel.nim
+++ b/dimscord/helpers/channel.nim
@@ -28,7 +28,7 @@ template edit*(ch: GuildChannel;
 ): Future[GuildChannel] =
     ## Modify a guild channel.
     getClient.api.editGuildChannel(
-        ch.id, name, parent_id, name, parent_id, topic, rtc_region,
+        ch.id, name, parent_id, topic, rtc_region,
         default_auto_archive_duration, video_quality_mode, flags, available_tags,
         default_reaction_emoji, default_sort_order, default_forum_layout,
         rate_limit_per_user, default_thread_rate_limit_per_user,
@@ -95,14 +95,14 @@ template deleteWebhook*(w: Webhook | string, reason = ""): Future[void] =
     let wid = when w is Webhook: w.id else: w
     getClient.api.deleteWebhook(wid, reason)
 
-template edit*(w: Webhook,
+template editWebhook*(w: Webhook,
         name, avatar = none string;
         reason = ""): Future[void] =
     let chan = w.channel_id
     if chan.isSome:
         getClient.api.editWebhook(w.id, name, avatar, w.channel_id, reason)
     else:
-        raise newException(CatchableError, "Webhook is not in a channel")
+        raise newException(CatchableError, "Webhook is not in a channel") # TODO: i think editWebhook can work with none(channel_id) ?
 
 template newThread*(ch: GuildChannel;
     name: string;

--- a/dimscord/helpers/channel.nim
+++ b/dimscord/helpers/channel.nim
@@ -13,7 +13,7 @@ template getPins*(ch: SomeChannel): Future[seq[Message]] =
     ## Get channel pins.
     getClient.api.getChannelPins(ch.id)
 
-template edit*(ch: GuildChannel;
+template editChannel*(ch: GuildChannel;
     name, parent_id, topic, rtc_region = none string;
     default_auto_archive_duration, video_quality_mode = none int;
     flags = none set[ChannelFlags];

--- a/dimscord/helpers/guild.nim
+++ b/dimscord/helpers/guild.nim
@@ -104,9 +104,9 @@ template removeMember*(g: Guild, m: Member, reason = ""): Future[void] =
     ## Removes a guild member.
     getClient.api.removeGuildMember(g.id, m.user.id, reason)
 
-template getBan*(g: Guild, m: Member): Future[GuildBan] =
+template getBan*(g: Guild, m: Member | string): Future[GuildBan] =
     ## Gets guild ban.
-    getClient.api.getGuildBan(g.id, m.user.id)
+    getClient.api.getGuildBan(g.id, (when m is Member: m.user.id else: m))
 
 template getBans*(g: Guild): Future[seq[GuildBan]] =
     ## Gets all the guild bans.

--- a/dimscord/helpers/guild.nim
+++ b/dimscord/helpers/guild.nim
@@ -20,7 +20,7 @@ template delete*(g: Guild): Future[void] =
     ## Deletes a guild. Requires guild ownership.
     getClient.api.deleteGuild(g.id)
 
-template editGuild*(g: Guild;  # TODO: template overloading bug
+template edit*(g: Guild;  # TODO: template overloading bug
         name, description, region, afk_channel_id, icon = none string;
         discovery_splash, owner_id, splash, banner = none string;
         system_channel_id, rules_channel_id = none string;
@@ -112,6 +112,13 @@ template getBans*(g: Guild): Future[seq[GuildBan]] =
     ## Gets all the guild bans.
     getClient.api.getGuildBans(g.id)
 
+template bulkBan*(g: Guild, m: Member,
+        user_ids: seq[string];
+        delete_message_seconds = 0;
+        reason = ""): Future[void] =
+    ## Creates a guild bulk ban.
+    getClient.api.bulkGuildBan(g.id, user_ids, delete_message_seconds, reason)
+
 template ban*(g: Guild, m: Member, delete_msg_days: range[0..7] = 0;
         reason = ""): Future[void] =
     ## Creates a guild ban.
@@ -178,7 +185,7 @@ template getScheduledEvents*(g: Guild): Future[seq[GuildScheduledEvent]] =
     ## Get all scheduled events in a guild.
     getClient.api.getScheduledEvents(g.id)
 
-template editGSE*(g: Guild, gse: GuildScheduledEvent; # TODO: template overloading bug 
+template editEvent*(g: Guild, gse: GuildScheduledEvent; # TODO: template overloading bug 
         name, start_time, image = none string;
         channel_id, end_time, desc = none string;
         privacy_level = none GuildScheduledEventPrivacyLevel;

--- a/dimscord/helpers/guild.nim
+++ b/dimscord/helpers/guild.nim
@@ -12,7 +12,7 @@ template getPruneCount*(g: Guild, days: int): Future[int] =
     ## Gets the prune count.
     getClient.api.getGuildPruneCount(g.id, days)
 
-template edit*(g: Guild, lvl: MFALevel; reason = ""): Future[MFALevel] =
+template editMFA*(g: Guild, lvl: MFALevel; reason = ""): Future[MFALevel] =
     ## Modify Guild MFA Level, requiring guild ownership.
     getClient.api.editGuildMFALevel(g.id, lvl, reason)
 

--- a/dimscord/helpers/guild.nim
+++ b/dimscord/helpers/guild.nim
@@ -20,7 +20,7 @@ template delete*(g: Guild): Future[void] =
     ## Deletes a guild. Requires guild ownership.
     getClient.api.deleteGuild(g.id)
 
-template edit*(g: Guild;
+template editGuild*(g: Guild;  # TODO: template overloading bug
         name, description, region, afk_channel_id, icon = none string;
         discovery_splash, owner_id, splash, banner = none string;
         system_channel_id, rules_channel_id = none string;
@@ -104,22 +104,22 @@ template removeMember*(g: Guild, m: Member, reason = ""): Future[void] =
     ## Removes a guild member.
     getClient.api.removeGuildMember(g.id, m.user.id, reason)
 
-template getBan*(g: Guild, user_id: string): Future[GuildBan] =
+template getBan*(g: Guild, m: Member): Future[GuildBan] =
     ## Gets guild ban.
-    getClient.api.getGuildBan(g.id, mb.user.id)
+    getClient.api.getGuildBan(g.id, m.user.id)
 
 template getBans*(g: Guild): Future[seq[GuildBan]] =
     ## Gets all the guild bans.
     getClient.api.getGuildBans(g.id)
 
-template ban*(g: Guild, m: Member, deletemsgdays: range[0..7] = 0;
+template ban*(g: Guild, m: Member, delete_msg_days: range[0..7] = 0;
         reason = ""): Future[void] =
     ## Creates a guild ban.
-    getClient.api.createGuildBan(g.id, m.user.id, deletemsgdays, reason)
+    getClient.api.createGuildBan(g.id, m.user.id, delete_msg_days, reason)
 
-template removeBan*(g: Guild, mb: Member, reason = ""): Future[void] =
+template removeBan*(g: Guild, m: Member, reason = ""): Future[void] =
     ## Removes a guild ban.
-    getClient.api.removeGuildBan(mb.guild_id, mb.user.id, reason)
+    getClient.api.removeGuildBan(g.id, m.user.id, reason)
 
 template getIntegrations*(g: Guild): Future[seq[Integration]] =
     ## Gets a list of guild integrations.
@@ -166,7 +166,7 @@ template editSticker*(g: Guild, s: Sticker;
 
 template deleteSticker*(g: Guild, sk: Sticker, reason = ""): Future[Sticker] =
     ## Deletes a guild sticker.
-    getClient.api.deleteGuildSticker(sk.guild_id.get, sk.id, reason)
+    getClient.api.deleteGuildSticker(sk.guild_id.get, sk.id, reason) # TODO: assert sk.guild_id.isSome, "Cannot delete Sticker: the bot is probably not in the sticker's owning guild."
 
 template getScheduledEvent*(g: Guild;
         event_id: string, with_user_count = false
@@ -178,7 +178,7 @@ template getScheduledEvents*(g: Guild): Future[seq[GuildScheduledEvent]] =
     ## Get all scheduled events in a guild.
     getClient.api.getScheduledEvents(g.id)
 
-template edit*(g: Guild, gse: GuildScheduledEvent;
+template editGSE*(g: Guild, gse: GuildScheduledEvent; # TODO: template overloading bug 
         name, start_time, image = none string;
         channel_id, end_time, desc = none string;
         privacy_level = none GuildScheduledEventPrivacyLevel;
@@ -198,7 +198,7 @@ template edit*(g: Guild, gse: GuildScheduledEvent;
         reason
     )
 
-template delete*(gse: GuildScheduledEvent, reason = ""): Future[void] =
+template delete*(gse: GuildScheduledEvent, reason = ""): Future[void] = 
    ## Delete a scheduled event in guild.
    getClient.api.deleteScheduledEvent(gse.guild_id, gse.id, reason)
 

--- a/dimscord/helpers/message.nim
+++ b/dimscord/helpers/message.nim
@@ -61,20 +61,15 @@ template edit*(m: Message;
         components
     )
 
-template delete*(m: Message | seq[Message] | seq[string];
-        reason = ""): Future[void] =
-    ## Deletes one or multiple Message(s).
-    when m is Message:
-        getClient.api.deleteMessage(m.channel_id, m.id, reason)
-    elif m is seq[string]:
-        getClient.api.bulkDeleteMessages(m[0].channel_id, m, reason)     
-    elif m is seq[Message]:
-        getClient.api.bulkDeleteMessages(
-            m[0].channel_id, 
-            (collect(newSeqOfCap m.len): 
-                for msg in m.items: msg.id),
-            reason
-        )
+template delete*(m: Message; reason = ""): Future[void] =
+    ## Deletes a discord Message.
+    getClient.api.deleteMessage(m.channel_id, m.id, reason)  
+
+template delete*(msgs: seq[Message]; reason = ""): Future[void] =
+    ## Bulk deletes messages.
+    ## Note: the length of `msg` MUST superior to 0 and inferior to 101.
+    getClient.api.bulkDeleteMessages(m[0].channel_id, msgs)
+
 
 template getMessages*(ch: SomeChannel;
         around, before, after = "";

--- a/dimscord/helpers/message.nim
+++ b/dimscord/helpers/message.nim
@@ -10,14 +10,16 @@ template send*(ch: SomeChannel;
     allowed_mentions = none AllowedMentions;
     message_reference = none MessageReference;
     components = newSeq[MessageComponent]();
-    sticker_ids = newSeq[string]()): Future[Message] =
+    sticker_ids = newSeq[string]();
+    poll = none PollRequest;
+    enforce_nonce = none bool): Future[Message] =
     ## Sends a Discord message.
     ## - `nonce` This can be used for optimistic message sending
     getClient.api.sendMessage(
         ch.id, content, tts,
         nonce, files, embeds,
         attachments, allowed_mentions, message_reference,
-        components, sticker_ids
+        components, sticker_ids, poll, enforce_nonce
     )
 
 template reply*(m: Message, content = "";
@@ -40,6 +42,22 @@ template reply*(m: Message, content = "";
         components, stickers
     )
 
+template editMessage*(c: SomeChannel, m: Message;
+        content = "";
+        embeds: seq[Embed] = @[];
+        attachments: seq[Attachment] = @[];
+        components: seq[MessageComponent] = @[];
+        files: seq[DiscordFile] = @[];
+        tts = false;
+        flags = none int): Future[Message]  =
+    ## Edits a Message.
+    getClient.api.editMessage(
+        c.id, m.id,
+        content, tts, flags,
+        files, embeds, attachments,
+        components
+    )
+
 template edit*(m: Message;
         content = "";
         embeds: seq[Embed] = @[];
@@ -47,8 +65,7 @@ template edit*(m: Message;
         components: seq[MessageComponent] = @[];
         files: seq[DiscordFile] = @[];
         tts = false;
-        flags = none int
-        ): Future[Message]  =
+        flags = none int): Future[Message]  =
     ## Edits a Message.
     getClient.api.editMessage(
         m.channel_id, m.id,
@@ -65,7 +82,6 @@ template delete*(msgs: seq[Message]; reason = ""): Future[void] =
     ## Bulk deletes messages.
     ## Note: the length of `msg` MUST superior to 0 and inferior to 101.
     getClient.api.bulkDeleteMessages(msgs[0].channel_id, msgs)
-
 
 template getMessages*(ch: SomeChannel;
         around, before, after = "";
@@ -96,24 +112,22 @@ template removeReactionEmoji*(m: Message, emoji: string): Future[void] =
     getClient.api.deleteMessageReactionEmoji(m.channel_id, m.id, emoji)
 
 template getReactions*(m: Message, emoji: string;
-        before, after = "";
+        kind: ReactionType = ReactionType.rtNormal;
+        after = "";
         limit: range[1..100] = 25
 ): Future[seq[User]] =
     ## Get all user message reactions on the emoji provided.
-    getClient.api.getMessageReactions(
-        m.channel_id, m.id, emoji,
-        before, after, limit
-    )
+    getClient.api.getMessageReactions(m.channel_id, m.id, emoji, kind, after, limit)
 
 template clearReactions*(m: Message): Future[void] =
     ## Remove all the reactions of a given message.
     getClient.api.deleteAllMessageReactions(m.channel_id, m.id)
 
 template getThreadMember*(ch: GuildChannel;
-        user: User | string): Future[ThreadMember] =
+        user: User | string; with_member = true): Future[ThreadMember] =
     ## Get a thread member.
     getClient.api.getThreadMember(
-        when user is User: user.id else: user
+        when user is User: user.id else: user, with_member
     )
 
 template getThreadMembers*(ch: GuildChannel): Future[seq[ThreadMember]] =
@@ -173,3 +187,16 @@ template startThread*(m: Message, name: string;
         m.channel_id, m.id, name,
         auto_archive_duration, reason
     )
+
+template endPoll*(m: Message, name: string;
+    auto_archive_duration: range[60..10080], reason = ""
+): Future[void] =
+    ## Ends poll.
+    getClient.api.endPoll(m.channel_id, m.id)
+
+template getPollAnswerVoters*(m: Message;
+    answer_id: string;
+    after = none string; limit: range[1..100] = 25
+): Future[seq[User]] =
+    ## Ends poll.
+    getClient.api.getPollAnswerVoters(m.channel_id, m.id, answer_id, after, limit)

--- a/dimscord/helpers/message.nim
+++ b/dimscord/helpers/message.nim
@@ -68,7 +68,7 @@ template delete*(m: Message; reason = ""): Future[void] =
 template delete*(msgs: seq[Message]; reason = ""): Future[void] =
     ## Bulk deletes messages.
     ## Note: the length of `msg` MUST superior to 0 and inferior to 101.
-    getClient.api.bulkDeleteMessages(m[0].channel_id, msgs)
+    getClient.api.bulkDeleteMessages(msgs[0].channel_id, msgs)
 
 
 template getMessages*(ch: SomeChannel;

--- a/dimscord/helpers/message.nim
+++ b/dimscord/helpers/message.nim
@@ -31,16 +31,12 @@ template reply*(m: Message, content = "";
         mention, failifnotexists, tts = false): Future[Message] =
     ## Replies to a Message.
     ## - set `mention` to `true` in order to mention the replied message in Discord.
-    let message_reference = block:
-        if mention: some m.reference
-        else: none MessageReference
-
     getClient.api.sendMessage(
         m.channel_id,
         content, tts, nonce,
         files, embeds, attachments,
         allowed_mentions, 
-        message_reference,
+        (if mention: some m.reference else: none MessageReference),
         components, stickers
     )
 

--- a/dimscord/helpers/user.nim
+++ b/dimscord/helpers/user.nim
@@ -16,14 +16,14 @@ template setNickname*(g: Guild, nick: string, reason = ""): Future[void] =
     ## - Set `nick` to "" to reset nickname.
     getClient.api.setGuildNick(g.id, nick, reason)
 
-template addRole*(mb: Member, r: Role | string, reason = ""): Future[void] =
-    ## Assigns a member's role.
-    let id = when r is Role: r.id else: r
-    getClient.api.addGuildMemberRole(mb.guild_id, mb.user.id, id, reason)
+# template addRole*(mb: Member, r: Role | string, reason = ""): Future[void] =
+#     ## Assigns a member's role.
+#     let id = when r is Role: r.id else: r
+#     getClient.api.addGuildMemberRole(mb.guild_id, mb.user.id, id, reason)
 
-template removeRole*(mb: Member, r: Role, reason = ""): Future[void] =
-    ## Removes a member's role.
-    getClient.api.removeGuildMemberRole(mb.guild_id, mb.user.id, r.id, reason)
+# template removeRole*(mb: Member, r: Role, reason = ""): Future[void] =
+#     ## Removes a member's role.
+#     getClient.api.removeGuildMemberRole(mb.guild_id, mb.user.id, r.id, reason)
 
 template leave*(g: Guild): Future[void] =
     ## Leaves a guild.
@@ -108,27 +108,23 @@ template reply*(i: Interaction;
         content = "";
         embeds: seq[Embed] = @[];
         components: seq[MessageComponent] = @[];
-        attachments: seq[Attachment] = @[];             
-        ephemeral = false
+        attachments: seq[Attachment] = @[];
+        allowed_mentions = default(AllowedMentions);           
+        tts = none bool; ephemeral = false
 ): Future[void] =
     ## Respond to an Interaction.
     ## - Do NOT use this if you used `defer` or if you already sent a `reply`. 
     ## - This is a "response" to an Interaction.
     ## Use `followup`, `createFollowupMessage` or `edit` if you already responded.
     ## - Set `ephemeral` to true to send ephemeral responses.
-
-    let flag = if ephemeral: {mfEphemeral} else: {}
-
     getClient.api.interactionResponseMessage(
         i.application_id,
         i.token,
         irtChannelMessageWithSource,
-        InteractionApplicationCommandCallbackData(
-            flags: flag,
-            content: content,
-            components: components,
-            attachments: attachments,
-            embeds: embeds
+        newInteractionData(
+            content, embeds, (if ephemeral: {mfEphemeral} else: {}),
+            attachments, components, 
+            allowed_mentions, tts
         )
     )
 
@@ -206,8 +202,7 @@ template delete*(i: Interaction, message_id = "@original"): Future[void] =
     ## Deletes an Interaction Response or Followup Message
     getClient.api.deleteInteractionResponse(i.application_id, i.token, message_id)
 
-template deferResponse*(i: Interaction;
-        ephemeral, hide = false): Future[void] =
+template deferResponse*(i: Interaction; ephemeral, hide = false): Future[void] =
     ## Defers the response/update to an Interaction.
     ## - You must use `followup()` or `edit()` after calling `defer()`.
     ## - Set `ephemeral` to `true` to make the Interaction ephemeral.
@@ -217,23 +212,17 @@ template deferResponse*(i: Interaction;
         i.id, 
         i.token, 
         InteractionResponse(
-            kind: (if hide: irtDeferredUpdateMessage
-            else: irtDeferredChannelMessageWithSource),
-            data: some InteractionCallbackDataMessage(
-                flags: if ephemeral: {mfEphemeral} else: {}
-            )
+            kind: (if hide: irtDeferredUpdateMessage else: irtDeferredChannelMessageWithSource),
+            data: some InteractionCallbackDataMessage(flags: (if ephemeral: {mfEphemeral} else: {}))
         )
     )
 
-template suggest*(i: Interaction;
-        choices: seq[ApplicationCommandOptionChoice]
-): Future[void] =
+template suggest*(i: Interaction; opts: seq[ApplicationCommandOptionChoice]): Future[void] =
     ## Create an interaction response which is an autocomplete response.
     getClient.api.interactionResponseAutocomplete(
-        i.id, i.token, InteractionCallbackDataAutocomplete(choices: choices))
+        i.id, i.token, InteractionCallbackDataAutocomplete(choices: opts)
+    )
 
-template sendModal*(i: Interaction;
-        response: InteractionCallbackDataModal
-): Future[void] =
+template sendModal*(i: Interaction; response: InteractionCallbackDataModal): Future[void] =
     ## Create an interaction response which is a modal.
     getClient.api.interactionResponseModal(i.id, i.token, response)

--- a/dimscord/helpers/user.nim
+++ b/dimscord/helpers/user.nim
@@ -171,7 +171,7 @@ template followup*(i: Interaction;
         flags = (if ephemeral: some mfEphemeral.ord else: none int)
     )
     
-template edit*(i: Interaction;
+template editInteraction*(i: Interaction;
         content = none string;
         embeds = newSeq[Embed]();
         allowed_mentions = none AllowedMentions;

--- a/dimscord/helpers/user.nim
+++ b/dimscord/helpers/user.nim
@@ -84,7 +84,7 @@ template bulkRegisterCommands*(app: Application;
         app.id, commands, guild_id
     )
 
-template editAC*(apc: ApplicationCommand;
+template editAppCmd*(apc: ApplicationCommand;
         name, desc = "";
         name_localizations,description_localizations = none Table[string,string];
         default_member_permissions = none PermissionFlags;

--- a/dimscord/helpers/user.nim
+++ b/dimscord/helpers/user.nim
@@ -171,7 +171,7 @@ template followup*(i: Interaction;
         flags = (if ephemeral: some mfEphemeral.ord else: none int)
     )
     
-template editInteraction*(i: Interaction;
+template editResponse*(i: Interaction;
         content = none string;
         embeds = newSeq[Embed]();
         allowed_mentions = none AllowedMentions;

--- a/dimscord/helpers/user.nim
+++ b/dimscord/helpers/user.nim
@@ -84,7 +84,7 @@ template bulkRegisterCommands*(app: Application;
         app.id, commands, guild_id
     )
 
-template edit*(apc: ApplicationCommand;
+template editAC*(apc: ApplicationCommand;
         name, desc = "";
         name_localizations,description_localizations = none Table[string,string];
         default_member_permissions = none PermissionFlags;

--- a/dimscord/helpers/user.nim
+++ b/dimscord/helpers/user.nim
@@ -24,9 +24,9 @@ template addRole*(mb: Member, r: Role | string, reason = ""): Future[void] =
     )
     getClient.api.addGuildMemberRole(mb.guild_id, mb.user.id, id, reason)
 
-# template removeRole*(mb: Member, r: Role, reason = ""): Future[void] =
-#     ## Removes a member's role.
-#     getClient.api.removeGuildMemberRole(mb.guild_id, mb.user.id, r.id, reason)
+template removeRole*(mb: Member, r: Role, reason = ""): Future[void] =
+    ## Removes a member's role.
+    getClient.api.removeGuildMemberRole(mb.guild_id, mb.user.id, r.id, reason)
 
 template leave*(g: Guild): Future[void] =
     ## Leaves a guild.
@@ -87,7 +87,7 @@ template bulkRegisterCommands*(app: Application;
         app.id, commands, guild_id
     )
 
-template editAppCmd*(apc: ApplicationCommand;
+template editCommand*(apc: ApplicationCommand;
         name, desc = "";
         name_localizations,description_localizations = none Table[string,string];
         default_member_permissions = none PermissionFlags;
@@ -159,7 +159,10 @@ template followup*(i: Interaction;
         attachments: seq[Attachment] = @[];
         files: seq[DiscordFile] = @[];
         allowed_mentions = none AllowedMentions;
-        tts, ephemeral = false): Future[Message] =
+        tts, ephemeral = false;
+        thread_id, thread_name = none string;
+        applied_tags: seq[string] = @[];
+        poll = none PollRequest): Future[Message] =
     ## Follow-up to an Interaction.
     ## - Use this function when sending messages to acknowledged Interactions.
     getClient.api.createFollowupMessage(
@@ -168,7 +171,11 @@ template followup*(i: Interaction;
         files, attachments,
         embeds, allowed_mentions,
         components,
-        flags = (if ephemeral: some mfEphemeral.ord else: none int)
+        flags = (if ephemeral: some mfEphemeral.ord else: none int),
+        applied_tags=applied_tags,
+        thread_name=thread_name,
+        thread_id=thread_id,
+        poll = poll,
     )
     
 template editResponse*(i: Interaction;
@@ -229,3 +236,6 @@ template suggest*(i: Interaction; opts: seq[ApplicationCommandOptionChoice]): Fu
 template sendModal*(i: Interaction; response: InteractionCallbackDataModal): Future[void] =
     ## Create an interaction response which is a modal.
     getClient.api.interactionResponseModal(i.id, i.token, response)
+
+
+# todo application??

--- a/dimscord/objects/macros.nim
+++ b/dimscord/objects/macros.nim
@@ -83,10 +83,10 @@ template getClient*: DiscordClient =
   when (declared(s)) and (typeof(s) is Shard):
     var dc {.cursor.} = s.client
     when defined(dimscordDebug): 
-      if dc.isNil: raise (ref AccessViolationDefect)(msg: "Client is Nil") # add a more descriptive error ?
+      if dc.isNil: raise (ref AccessViolationDefect)(msg: "Client is nil: Please check if you have a properly initialized client.") 
     dc
   else:
-    {.error: "Error: Cannot find any Shard in scope.\nHelpers must have the 's' variable in scope in order to work".}
+    {.error: "Error: Cannot find any Shard in scope. Helpers must have a 's' variable of type `Shard` in the current scope in order to work".}
 
 
 

--- a/examples/helpers.nim
+++ b/examples/helpers.nim
@@ -97,11 +97,11 @@ proc interactionCreate(s: Shard, i: Interaction) {.event(discord).} =
     await i.deferResponse(hide = true)
     case data.custom_id
     of "addBtn":
-        await! i.edit(
+        await! i.editInteraction(
             some "Current Count: " & $(num + 1)
         )
     of "subBtn":
-        await! i.edit(
+        await! i.editInteraction(
             some "Current Count: " & $(num - 1)
         )    
 

--- a/examples/helpers.nim
+++ b/examples/helpers.nim
@@ -97,11 +97,11 @@ proc interactionCreate(s: Shard, i: Interaction) {.event(discord).} =
     await i.deferResponse(hide = true)
     case data.custom_id
     of "addBtn":
-        await! i.editInteraction(
+        await! i.editResponse(
             some "Current Count: " & $(num + 1)
         )
     of "subBtn":
-        await! i.editInteraction(
+        await! i.editResponse(
             some "Current Count: " & $(num - 1)
         )    
 


### PR DESCRIPTION
## implementation fixes
Some helpers were preventing code to compile because of bad implementation causing compiler errors. Those were fixed in this PR.
 
## template renaming
Some helpers have been renamed because of overloading too much which was especially the case of the `edit` identifier  which confused the compiler sometimes. 

## 
## `getClient` and `mainClient`
In some Nim versions, users may encounter "client not found" or "client not registered" errors due to compiler bugs that have now been resolved. As a result, this feature works on recent versions of the compiler but not on older ones.

`mainClient` is now a no-op. We can reserve it for future versions of the library in case we need it again (reverting to the old behavior or implementing another solution mentioned down below). We can also deprecate it if we decide that it's no longer necessary.

`getClient` now works by finding the 's' symbol which is always available within event handlers or command handlers like in `dimscmd`. It also checks if the 's' symbol is a Shard in case the user (for some obscure reason) decides to shadow it. This should work fine in older versions since it relies on less complex features of the language.

However, this means we can no longer use the helpers outside of event or command handlers, for example after this patch it won't be possible to use helpers with a client that has [`rest_mode = true`](https://github.com/krisppurg/dimscord/blob/master/examples/rest_api.nim) because they cannot use event handlers. I decided the fix was worth it because it makes the most common use-cases more reliable. 

One idea I had to mitigate this problem is to modify `mainClient` again to generate a template that [aliases](https://nim-lang.org/docs/manual_experimental.html#symbols-as-templateslashmacro-calls-alias-syntax) the user's client, allowing us to use the real symbol by calling `getClient` without relying on the old method again:
```nim
# objects/macros
import  macros, strutils

macro mainClient*(variable: untyped): untyped =
  let templateName = ident("dimscordPrivateClient")
  result = quote do: # 
    template `templateName`*(): untyped {.dirty.} =
      `variable`

template getClient*: DiscordClient = 
  ## Tries to access DiscordClient by using a Shard or an alias. Internal use only.
  when (declared(dimscordPrivateClient)):
    var dc {.cursor.} = dimscordPrivateClient
  elif (declared(s)) and (typeof(s) is Shard):
    var dc {.cursor.} = s.client
    when defined(dimscordDebug): 
      if dc.isNil: raise (ref AccessViolationDefect)(msg: "Client is nil: Please check if you have a properly initialized client.") 
    dc
  else:
    {.error: "Error: Cannot find any client in scope. You must use `mainClient` or have a 's' variable of type `Shard` in the current scope in order to work".}
```

### Example usage:
```nim

let discord {.mainClient.} = newDiscordClient("token", rest_mode = true)  
var channel: GuildChannel = waitFor discord.api.getChannel("channel_id")

# when a helper is used:
var channel: GuildChannel = waitFor discord.api.getChannel("channel_id")
var msg = waitFor channel.send("hello!")

# it should become..
var channel: GuildChannel = waitFor discord.api.getChannel("channel_id")
var msg = waitFor discord.api.sendMessage(
        ch.id, "hello", false,
        none(int), @[], @[],
        @[], none AllowedMention, none MessageReference,
        newSeq[MessageComponent](), newSeq[string]()
    )
```
 
 ## Future work
Because nim templates are lazy we have to use them so that they are instantiated, the compiler cannot tell us if the template is good otherwise. So a CI/test-suite will follow-up this PR in order to test if they work correctly. 

