### PR TITLE
Don't update message in cache by reference

### DIFF
--- a/dimscord/dispatch.nim
+++ b/dimscord/dispatch.nim
@@ -406,29 +406,27 @@ proc messageDelete(s: Shard, data: JsonNode) {.async.} =
     s.checkAndCall(MessageDelete, msg, exists)
 
 proc messageUpdate(s: Shard, data: JsonNode) {.async.} =
-    ## Updates message in cache using data from event.
-    ## Message inside cache will not be updated until after the handler is called
     var
         msg = Message(
             id: data["id"].str,
             channel_id: data["channel_id"].str)
-        oldMsg: Message = nil
     # Get the messages table if the channel is in the cache
-    let message {.cursor.} =
+    var messages {.cursor.} =
         if msg.channel_id in s.cache.guildChannels:
-            messages = s.cache.guildChannels[msg.channel_id].messages
+            s.cache.guildChannels[msg.channel_id].messages
         elif msg.channel_id in s.cache.dmChannels:
-            messages = s.cache.dmChannels[msg.channel_id].messages
+            s.cache.dmChannels[msg.channel_id].messages
+        else: initTable[string, Message](0)
     let
-      exists = msg.id in messages
-      # Use the version from cache if we can
-      oldMsg = if exists: messages[msg.id] else: nil
-      # Update the message from cache, or just use what we have
-      newMsg = if exists: oldMsg.update(data) else: msg
+        exists = msg.id in messages
+        # Use the version from cache if we can
+        oldMsg = if exists: messages[msg.id] else: nil
+        # Update the message from cache, or just use what we have
+        newMsg = if exists: oldMsg.updateMessage(data) else: msg
+    # Update the messages
+    if exists:
+        messages[msg.id] = newMsg
     s.checkAndCall(MessageUpdate, newMsg, option(oldMsg), exists)
-    # Update it if its inside the cache
-    if oldMsg != nil:
-        messages[msg.id][] = newMsg[]
 
 proc messageDeleteBulk(s: Shard, data: JsonNode) {.async.} =
     var mids: seq[tuple[msg: Message, exists: bool]] = @[]

--- a/dimscord/objects.nim
+++ b/dimscord/objects.nim
@@ -655,7 +655,9 @@ proc newInviteMetadata*(data: JsonNode): InviteMetadata =
     result = data.`$`.fromJson(InviteMetadata)
 
 proc updateMessage*(m: Message, data: JsonNode): Message =
-    result = m
+    ## Copies `m` and returns a new instance with updated fields from `data`
+    result = new Message
+    result[] = m[]
 
     with result:
         mention_users = data{"mentions"}.getElems.map(newUser)
@@ -878,7 +880,7 @@ proc renameHook(v: var ApplicationCommand, fieldName: var string) {.used.} =
     if fieldName == "type":
         fieldName = "kind"
 
-proc newEntitlement*(data: JsonNode): Entitlement = 
+proc newEntitlement*(data: JsonNode): Entitlement =
     result = data.`$`.fromJson(Entitlement)
 
 proc newApplicationCommandInteractionData*(


### PR DESCRIPTION
Fixes #127 

Since `Message` is a reference, when we update the message in the table it was updated the message. Fix is to copy the message and then add the new message into cache (Think this might've been my fault when trying to move away from deepcopy?)

Testing evidence that it can message in cache and not in cache
Using this test code
```nim
proc messageUpdate(s: Shard, m: Message, old: Option[Message], exists: bool) {.event(discord).} =
  if old.isSome:
    echo "Old: ", old.get().content
    echo "New: ", m.content
  else:
    echo "No old message"
```
![image](https://github.com/user-attachments/assets/ddb3576a-97a6-4392-9c24-57d101dcf827)
